### PR TITLE
Correct mistake in finishSolveStepByStep()

### DIFF
--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -1127,7 +1127,7 @@ namespace hpp
       void Problem::finishSolveStepByStep () throw (hpp::Error)
       {
 	try {
-	  problemSolver()->solve();
+         problemSolver()->finishSolveStepByStep();
 	} catch (const std::exception& exc) {
 	  throw hpp::Error (exc.what ());
 	}


### PR DESCRIPTION
Problem::finishSolveStepByStep() called problemSolver::solve()