### PR TITLE
Handle locked joints and bind right hand side related methods

### DIFF
--- a/idl/hpp/corbaserver/problem.idl
+++ b/idl/hpp/corbaserver/problem.idl
@@ -307,6 +307,19 @@ module hpp
     boolean getConstantRightHandSide (in string constraintName)
       raises (Error);
 
+    /// Set right hand side of constraints in config projector
+    /// \param rhs right hand side of constraints. Contains only right hand side
+    ///        of non-constant constraints
+    /// \note Locked joints are also considered.
+    void setRightHandSide (in floatSeq rhs) raises (Error);
+
+    /// Set right hand side of given constraint in config projector
+    /// \param constraintName name of the numerical constraint or locked joint
+    /// \param rhs right hand side of constraint. raises an exception if
+    ///        constraint has constant right hand side.
+    void setRightHandSideByName (in string constraintName, in floatSeq rhs)
+      raises (Error);
+
     /// Set numerical constraints by names in ConfigProjector
     /// \param configProjName Name of the config projector if created by this
     ///        method,

--- a/idl/hpp/corbaserver/problem.idl
+++ b/idl/hpp/corbaserver/problem.idl
@@ -164,11 +164,29 @@ module hpp
     /// \param mask Select which axis to be constrained.
     /// If joint1 of joint2 is "", the corresponding joint is replaced by
     /// the global frame.
-    /// constraints are stored in ProblemSolver object
+    /// constraints are stored in ProblemSolver object with key constraintName
     void createTransformationConstraint
     (in string constraintName, in string joint1Name,
      in string joint2Name, in Transform_ ref,
      in boolSeq mask) raises (Error);
+
+    /// Create a LockedJoint constraint with given value
+    /// \param lockedJointName key of the constraint in the ProblemSolver map,
+    /// \param jointName name of the joint,
+    /// \param value value of the joint configuration,
+    void createLockedJoint (in string lockedJointName,
+                            in string jointName,
+                            in floatSeq value) raises (Error);
+
+    /// Create a locked extradof
+    ///        hpp::manipulation::ProblemSolver map
+    /// \param lockedDofName key of the constraint in the Problem Solver map
+    /// \param index index of the extra dof (0 means the first extra dof)
+    /// \param value value of the extra dof configuration. The size
+    ///              of this vector defines the size of the constraints.
+    void createLockedExtraDof (in string lockedDofName,
+                               in unsigned long index,
+                               in floatSeq value) raises (Error);
 
 
     /// Create ComBeetweenFeet constraint between two joints

--- a/idl/hpp/corbaserver/problem.idl
+++ b/idl/hpp/corbaserver/problem.idl
@@ -308,14 +308,24 @@ module hpp
       raises (Error);
 
     /// Set numerical constraints by names in ConfigProjector
-    /// \param constraintName Name of the set of numerical constraint,
+    /// \param configProjName Name of the config projector if created by this
+    ///        method,
     /// \param constraintNames names of the constraints to apply,
     ///
     /// Constraints should have been added in the ProblemSolver local map.
-    void setNumericalConstraints (in string constraintName,
+    void setNumericalConstraints (in string configProjName,
 				  in Names_t constraintNames,
                                   in intSeq priorities)
       raises (Error);
+
+    /// Set locked joints by names in ConfigProjector
+    /// \param configProjName Name of the config projector if created by this
+    ///        method,
+    /// \param lockedJointNames names of the locked joints,
+    ///
+    /// Locked joints should have been added in the ProblemSolver local map.
+    void setLockedJointConstraints (in string configProjName,
+                                    in Names_t lockedJointNames) raises (Error);
 
     /// Lock joint with given joint configuration
     /// \param jointName name of the joint

--- a/src/hpp/corbaserver/problem_solver.py
+++ b/src/hpp/corbaserver/problem_solver.py
@@ -325,14 +325,24 @@ class ProblemSolver (object):
 
     ## Set numerical constraints in ConfigProjector
     #
-    #  \param name name of the resulting numerical constraint obtained
-    #         by stacking elementary numerical constraints,
-    #  \param names list of names of the numerical constraints as
-    #         inserted by method hpp::core::ProblemSolver::addNumericalConstraint.
+    #  \param name name of the config projector created if any,
+    #  \param names list of names of the numerical constraints previously
+    #         created by methods createTransformationConstraint,
+    #         createRelativeComConstraint, ...
     def setNumericalConstraints (self, name, names, priorities = None):
         if priorities is None:
             priorities = [ 0 for i in names ]
-        return self.client.problem.setNumericalConstraints (name, names, priorities)
+        return self.client.problem.setNumericalConstraints \
+            (name, names, priorities)
+
+    ## Set locked joint in ConfigProjector
+    #
+    #  \param name name of the config projector created if any,
+    #  \param names list of names of the locked joints previously created by
+    #         method createLockedJoint.
+    def setLockedJointConstraints (self, name, names, priorities = None):
+        return self.client.problem.setLockedJointConstraints \
+            (name, names, priorities)
 
     ## Apply constraints
     #
@@ -390,6 +400,9 @@ class ProblemSolver (object):
     # \param jointName name of the joint
     # \param value value of the joint configuration
     def lockJoint (self, jointName, value):
+        from warnings import warn
+        warn ("method lockJoint is deprecated: use createLockedJoint and "
+              + "setConstraints instead")
         return self.client.problem.lockJoint (jointName, value)
 
     ## error threshold in numerical constraint resolution

--- a/src/hpp/corbaserver/problem_solver.py
+++ b/src/hpp/corbaserver/problem_solver.py
@@ -344,6 +344,20 @@ class ProblemSolver (object):
         return self.client.problem.setLockedJointConstraints \
             (name, names, priorities)
 
+    ## Set right hand side of constraints in config projector
+    #  \param rhs right hand side of constraints. Contains only right hand side
+    #         of non-constant constraints
+    #  \note Locked joints are also considered.
+    def setRightHandSide (self, rhs):
+        return self.client.problem.setRightHandSide (rhs)
+
+    ## Set right hand side of given constraint in config projector
+    #  \param constraintName name of the numerical constraint or locked joint
+    #  \param rhs right hand side of constraint. raises an exception if
+    #         constraint has constant right hand side.
+    def setRightHandSideByName (self, constraintName, rhs):
+        return self.client.problem.setRightHandSideByName (constraintName, rhs)
+
     ## Apply constraints
     #
     #  \param q initial configuration

--- a/src/hpp/corbaserver/problem_solver.py
+++ b/src/hpp/corbaserver/problem_solver.py
@@ -220,6 +220,24 @@ class ProblemSolver (object):
         return self.client.problem.createTransformationConstraint \
             (constraintName, joint1Name, joint2Name, ref, mask)
 
+    ## Create a LockedJoint constraint with given value
+    #  \param lockedJointName key of the constraint in the ProblemSolver map,
+    #  \param jointName name of the joint,
+    #  \param value value of the joint configuration,
+    def createLockedJoint (self, lockedDofName, jointName, value):
+        return self.client.problem.createLockedJoint \
+            (lockedDofName, jointName, value)
+
+    ## Create a locked extradof
+    #         hpp::manipulation::ProblemSolver map
+    #  \param lockedDofName key of the constraint in the Problem Solver map
+    #  \param index index of the extra dof (0 means the first extra dof)
+    #  \param value value of the extra dof configuration. The size
+    #               of this vector defines the size of the constraints.
+    def createLockedExtraDof (self, lockedDofName, index, value):
+        return self.client.problem.createLockedExtraDof \
+            (lockedDofName, index, value)
+
     ## Create RelativeCom constraint between two joints
     #
     #  \param constraintName name of the constraint created,

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -1175,6 +1175,56 @@ namespace hpp
 	}
       }
 
+      void Problem::setRightHandSide (const hpp::floatSeq& rhs)
+          throw (hpp::Error)
+      {
+        try {
+          hpp::core::ConfigProjectorPtr_t configProjector
+            (problemSolver ()->constraints ()->configProjector ());
+          if (!configProjector) {
+            throw std::runtime_error ("No constraint has been set.");
+          }
+          vector_t rightHandSide (floatSeqToVector (rhs));
+          configProjector->rightHandSide (rightHandSide);
+        } catch (const std::exception& exc) {
+          throw hpp::Error (exc.what ());
+        }
+      }
+
+      void Problem::setRightHandSideByName (const char* constraintName,
+                                            const hpp::floatSeq& rhs)
+        throw (hpp::Error)
+      {
+        try {
+          hpp::core::ConfigProjectorPtr_t configProjector
+            (problemSolver ()->constraints ()->configProjector ());
+          if (!configProjector) {
+            throw std::runtime_error ("No constraint has been set.");
+          }
+          vector_t rightHandSide (floatSeqToVector (rhs));
+          // look for constraint with this key
+          if (problemSolver ()->has <core::NumericalConstraintPtr_t>
+              (constraintName)) {
+            core::NumericalConstraintPtr_t nc
+              (problemSolver ()->get <core::NumericalConstraintPtr_t>
+               (constraintName));
+            configProjector->rightHandSide (nc, rightHandSide);
+            return;
+          }
+          if (problemSolver ()->has <LockedJointPtr_t> (constraintName)) {
+            LockedJointPtr_t lj
+              (problemSolver ()->get <LockedJointPtr_t> (constraintName));
+            configProjector->rightHandSide (lj, rightHandSide);
+            return;
+          }
+          std::string msg ("Config projector does not contain any constraint or locked joint with name ");
+          msg += constraintName;
+          throw std::runtime_error (msg.c_str ());
+        } catch (const std::exception& exc) {
+          throw hpp::Error (exc.what ());
+        }
+      }
+
       // ---------------------------------------------------------------
 
       void Problem::setNumericalConstraints

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -1178,7 +1178,7 @@ namespace hpp
       // ---------------------------------------------------------------
 
       void Problem::setNumericalConstraints
-      (const char* constraintName, const Names_t& constraintNames,
+      (const char* configProjName, const Names_t& constraintNames,
        const hpp::intSeq& priorities)
 	throw (Error)
       {
@@ -1186,8 +1186,29 @@ namespace hpp
 	try {
 	  for (CORBA::ULong i=0; i<constraintNames.length (); ++i) {
 	    std::string name (constraintNames [i]);
-            problemSolver()->addFunctionToConfigProjector (constraintName, name,
+            problemSolver()->addNumericalConstraintToConfigProjector
+              (configProjName, name,
                 (std::size_t)priorities[i]);
+	    problemSolver()->robot ()->controlComputation
+	      (pinocchio::Device::ALL);
+	  }
+	} catch (const std::exception& exc) {
+	  throw Error (exc.what ());
+	}
+      }
+
+      // ---------------------------------------------------------------
+
+      void Problem::setLockedJointConstraints
+      (const char* configProjName,const hpp::Names_t& lockedJointNames)
+        throw (Error)
+      {
+        if (!problemSolver()->robot ()) throw hpp::Error ("No robot loaded");
+	try {
+	  for (CORBA::ULong i=0; i<lockedJointNames.length (); ++i) {
+	    std::string name (lockedJointNames [i]);
+            problemSolver()->addLockedJointToConfigProjector
+              (configProjName, name);
 	    problemSolver()->robot ()->controlComputation
 	      (pinocchio::Device::ALL);
 	  }

--- a/src/problem.impl.hh
+++ b/src/problem.impl.hh
@@ -162,6 +162,13 @@ namespace hpp
         virtual bool getConstantRightHandSide (const char* constraintName)
           throw (hpp::Error);
 
+        virtual void setRightHandSide (const hpp::floatSeq& rhs)
+          throw (hpp::Error);
+
+        virtual void setRightHandSideByName (const char* constraintName,
+                                             const hpp::floatSeq& rhs)
+          throw (hpp::Error);
+
 	virtual void resetConstraints () throw (hpp::Error);
 	virtual void setNumericalConstraints
 	(const char* constraintName, const hpp::Names_t& constraintNames,

--- a/src/problem.impl.hh
+++ b/src/problem.impl.hh
@@ -76,6 +76,16 @@ namespace hpp
 	 const char* joint2Name, const Transform_ p, const hpp::boolSeq& mask)
 	  throw (hpp::Error);
 
+        virtual void createLockedJoint (const char* lockedJointName,
+                                        const char* jointName,
+                                        const hpp::floatSeq& value)
+          throw (hpp::Error);
+
+        virtual void createLockedExtraDof (const char* lockedDofName,
+                                           ULong index,
+                                           const hpp::floatSeq& value)
+          throw (hpp::Error);
+
         void createRelativeComConstraint (const char* constraintName,
             const char* comn, const char* jointName, const floatSeq& point,
             const hpp::boolSeq& mask)

--- a/src/problem.impl.hh
+++ b/src/problem.impl.hh
@@ -167,6 +167,11 @@ namespace hpp
 	(const char* constraintName, const hpp::Names_t& constraintNames,
          const hpp::intSeq& priorities)
 	  throw (Error);
+
+        virtual void setLockedJointConstraints
+        (const char* configProjName,const hpp::Names_t& lockedJointNames)
+          throw (Error);
+
 	virtual void lockJoint (const char* jointName,
 				const hpp::floatSeq& value)
 	  throw (hpp::Error);


### PR DESCRIPTION
1. Locked Joint manipulation has been moved from hpp-manipulation to hpp-core.
2. Right hand side of constraints in config projector can now be set by interface methods.
