### PR TITLE
fix tests, add .gitlab-ci.yml & badges

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,56 @@
+# Please don't edit this file, and use the version generated at
+# http://rainboard.laas.fr/project/hpp-corbaserver/.gitlab-ci.yml
+
+variables:
+  GIT_SUBMODULE_STRATEGY: "recursive"
+  CCACHE_BASEDIR: "${CI_PROJECT_DIR}"
+  CCACHE_DIR: "${CI_PROJECT_DIR}/ccache"
+
+cache:
+  paths:
+    - ccache
+
+.robotpkg-hpp-corbaserver: &robotpkg-hpp-corbaserver
+  except:
+    - gh-pages
+  script:
+    - mkdir -p ccache
+    - cd /root/robotpkg/path
+    - git pull
+    - cd hpp-corbaserver
+    - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
+    - make install
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - make test
+
+robotpkg-hpp-corbaserver-14.04-release:
+  <<: *robotpkg-hpp-corbaserver
+  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-corbaserver/hpp-corbaserver:14.04
+
+robotpkg-hpp-corbaserver-16.04-release:
+  <<: *robotpkg-hpp-corbaserver
+  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-corbaserver/hpp-corbaserver:16.04
+
+robotpkg-hpp-corbaserver-18.04-release:
+  <<: *robotpkg-hpp-corbaserver
+  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-corbaserver/hpp-corbaserver:18.04
+
+doc-coverage:
+  <<: *robotpkg-hpp-corbaserver
+  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-corbaserver/hpp-corbaserver:16.04
+  before_script:
+    - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
+  after_script:
+    - cd /root/robotpkg/path/hpp-corbaserver
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - make doc
+    - mv doc/doxygen-html ${CI_PROJECT_DIR}
+    - mkdir -p ${CI_PROJECT_DIR}/coverage/
+    - gcovr -r .
+    - gcovr -r . --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - doxygen-html/
+      - coverage/
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,8 @@ cache:
     - cd hpp-corbaserver
     - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
     - make install
-    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)/build
+    - rm -rf src/hpp/corbaserver/hpp
     - make test
 
 robotpkg-hpp-corbaserver-14.04-release:
@@ -42,7 +43,7 @@ doc-coverage:
     - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
   after_script:
     - cd /root/robotpkg/path/hpp-corbaserver
-    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)/build
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}
     - mkdir -p ${CI_PROJECT_DIR}/coverage/
@@ -53,4 +54,3 @@ doc-coverage:
     paths:
       - doxygen-html/
       - coverage/
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,10 +22,6 @@ cache:
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)/build
 
-robotpkg-hpp-corbaserver-14.04-release:
-  <<: *robotpkg-hpp-corbaserver
-  image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-corbaserver/hpp-corbaserver:14.04
-
 robotpkg-hpp-corbaserver-16.04-release:
   <<: *robotpkg-hpp-corbaserver
   image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-corbaserver/hpp-corbaserver:16.04

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,8 +21,6 @@ cache:
     - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)/build
-    - rm -rf src/hpp/corbaserver/hpp
-    - make test
 
 robotpkg-hpp-corbaserver-14.04-release:
   <<: *robotpkg-hpp-corbaserver
@@ -46,9 +44,6 @@ doc-coverage:
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)/build
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}
-    - mkdir -p ${CI_PROJECT_DIR}/coverage/
-    - gcovr -r .
-    - gcovr -r . --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
   artifacts:
     expire_in: 1 day
     paths:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# HPP-corbaserver
+
+[![Building Status](https://travis-ci.org/humanoid-path-planner/hpp-corbaserver.svg?branch=master)](https://travis-ci.org/humanoid-path-planner/hpp-corbaserver)
+[![Pipeline status](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-corbaserver/badges/master/pipeline.svg)](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-corbaserver/commits/master)
+[![Coverage report](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-corbaserver/badges/master/coverage.svg?job=doc-coverage)](http://projects.laas.fr/gepetto/doc/humanoid-path-planner/hpp-corbaserver/master/coverage/)
+
 Corba server for Humanoid Path Planner applications.
 
 # Troubleshooting
@@ -20,5 +26,3 @@ then restart the server:
 ```bash
 sudo service omniorb4-nameserver restart
 ```
-
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,1 @@
-CONFIG_FILES(robot.py)
-ADD_PYTHON_UNIT_TEST(robot.py robot.py)
+ADD_PYTHON_UNIT_TEST(robot.py tests/robot.py src)

--- a/tests/robot.py
+++ b/tests/robot.py
@@ -1,6 +1,5 @@
 from subprocess import Popen
 import unittest, sys
-sys.path.insert(0, "@CMAKE_BINARY_DIR@/src")
 
 from hpp.corbaserver import Client
 from hpp.corbaserver.robot import Robot
@@ -8,7 +7,7 @@ from hpp.corbaserver.robot import Robot
 class Test (unittest.TestCase):
     @classmethod
     def setUpClass (cls):
-        cls.server = Popen (["@CMAKE_BINARY_DIR@/src/hppcorbaserver"], stdout = sys.stdout)
+        cls.server = Popen (["../src/hppcorbaserver"], stdout = sys.stdout)
         # Give some time to the server to start
         from time import sleep
         sleep(0.01)


### PR DESCRIPTION
Hi,

Tests have been disabled by 1971709d5f39e495e5a0b09c2d75953b02801c5a. This PR enable them again, and almost fix them.

I still have 2 issues:
- omniidl creates the `build/src/hpp/corbaserver/hpp/corbaserver` folder, which really looks like a mistake, so I remove it before launching tests: `mkdir build; cd build; cmake ..; make -j8; rm -rf src/hpp/corbaserver/hpp; make test` -> raise #56 
- the test is passing on my desktop computer, but I can't get it work for now on the CI, probably because of some issues with omniNames & docker -> raise #57 