### PR TITLE
fix build in c++11

### DIFF
--- a/src/servant-base.hh
+++ b/src/servant-base.hh
@@ -142,7 +142,7 @@ namespace hpp
 
         // Mimic boost::shared_ptr<D> interface:
         typedef T element_type;
-        operator bool () const { return element; }
+        operator bool () const { return (bool)element; }
     };
 
     typedef PortableServer::Servant_var<PortableServer::ServantBase> ServantBase_var;


### PR DESCRIPTION
With an explicit cast from `shared_ptr` to `bool.

While here, rename `paths`' `print` to `show`, as defining `print` can raise a `SyntaxError` in python 2. I don't understand why this error does not appear on 16.04. My guess is that the generated file is not called properly.

Another error prevents the test `py-robot` to pass, but this seems less trivial, so I'm opening a separate issue.