### PR TITLE
Modify the way urdf and srdf files are handled

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,15 @@
+New in 5.0.0
+* Modify the way urdf and srdf files are handled. See porting notes in html documentaion
 
+New in 4.7.0
+* Bind CenterOfMassComputation. 
+* Bind Path::reverse
+* Bind functions integrate, difference, interpolate and saturate.
+* Handle LockedJointPtr_t instances the same way as ImplicitPtr_t: use the same container.
+* Use inout in IDL when possible.
+* Bind method BySubstitution::isConstraintSatisfied
+* Make Python code Python 3 compatible, add CMake variable to choose Python version
+* Re-introduce method ProblemSolver.addConfigValidation.
 New in 4.6.1
 * Remove deprecated methods
 

--- a/doc/porting-from-4-to-5.hh
+++ b/doc/porting-from-4-to-5.hh
@@ -1,0 +1,39 @@
+/// \page hpp_corbaserver_porting_notes Porting notes
+///
+/// \section hpp_corbaserver_porting_4_to_5 Porting your code from version 4 to 5
+/// \subsection hpp_corbaserver_porting_4_to_5_1 Modification of idl API
+///
+/// \subsubsection hpp_corbaserver_porting_4_to_5_1_1 Method
+/// hpp::corbaserver::Obstacle::loadObstacleModel has been split in two methods
+///
+/// \li hpp::corbaserver::Obstacle::loadObstacleModel (in string filename, in string prefix), and
+/// \li hpp::corbaserver::Obstacle::loadObstacleModelFromString (in string urdfString, in string prefix).
+///
+/// Arguments to loadObstacleModel are now
+/// \li a filename and a prefix, instead of
+/// \li a package name, a filename radical and a prefix.
+///
+/// As in many other methods and functions, the filename now includes reference
+/// to the package: "package://...".
+///
+/// \subsubsection hpp_corbaserver_porting_4_to_5_1_2 Methods
+/// hpp::corbaserver::Robot::loadRobotModel and hpp::corbaserver::Robot::loadHumanoidModel
+///
+/// Arguments
+/// \li in string packageName, in string modelName, in string urdfSuffix, in string srdfSuffix have been replaced by
+/// \li in string urdfName, in string srdfName.
+///
+/// As in the previous section these latter arguments contain the full filenames
+/// to the urdf and srdf files.
+///
+/// 
+/// \subsection hpp_corbaserver_porting_4_to_5_2 Modification of python API
+///
+/// \subsubsection hpp_corbaserver_porting_4_to_5_2_1 Method
+/// hpp.corbaserver.problem_solver.ProblemSolver.loadObstacleFromUrdf
+///
+/// Arguments
+/// \li package, filename have been replaced by
+/// \li filename.
+/// Calling the method with 3 arguments interpretes arguments as (package, filename, prefix) and raises a warning.
+/// Note that it is not possible to call arguments by names.

--- a/idl/hpp/corbaserver/obstacle.idl
+++ b/idl/hpp/corbaserver/obstacle.idl
@@ -22,19 +22,25 @@ module hpp
     /// Load obstacle from urdf file
     ///
     /// \param package Name of the package containing the model.
-    /// \param file If package is empty, this is the XML string to parse
-    ///             otherwise, this is the filename of the urdf file in the package
-    ///        (without suffix .urdf)
+    /// \param filename name of the urdf file, it may contain "package://" 
     /// \param prefix prefix added to object names in case the same file is
     ///        loaded several times
     ///
-    /// The ros url is built as follows:
-    /// "package://${package}/urdf/${filename}.urdf"
+    /// The kinematic structure of the urdf file is ignored. Only the geometric
+    /// objects are loaded as obstacles.
+    void loadObstacleModel (in string filename, in string prefix)
+      raises (Error);
+
+    /// Load obstacle from urdf file
+    ///
+    /// \param package Name of the package containing the model.
+    /// \param urdfString XML string to parse
+    /// \param prefix prefix added to object names in case the same file is
+    ///        loaded several times
     ///
     /// The kinematic structure of the urdf file is ignored. Only the geometric
     /// objects are loaded as obstacles.
-    void loadObstacleModel (in string package, in string file,
-			    in string prefix)
+    void loadObstacleModelFromString (in string urdfString, in string prefix)
       raises (Error);
 
     /// \brief Remove an obstacle from outer objects of a joint body

--- a/idl/hpp/corbaserver/robot.idl
+++ b/idl/hpp/corbaserver/robot.idl
@@ -27,17 +27,13 @@ module hpp
     /// \param robotName Name of the robot that is constructed,
     /// \param rootJointType type of root joint among "anchor", "freeflyer",
     /// "planar",
-    /// \param packageName Name of the ROS package containing the model,
-    /// \param modelName Name of the package containing the model
-    /// \param urdfSuffix suffix for urdf file,
-    ///
-    /// The ros url are built as follows:
-    /// - \c package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf
-    /// - \c package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf
+    /// \param urdfName name of the urdf file. It may contain
+    ///        "file://", or "package://" prefixes.
+    /// \param srdfName name of the srdf file. It may contain
+    ///        "file://", or "package://" prefixes.
     ///
     void loadRobotModel (in string robotName, in string rootJointType,
-			 in string packageName, in string modelName,
-			 in string urdfSuffix, in string srdfSuffix)
+			 in string urdfName, in string srdfName)
       raises (Error);
 
     ///  Load humanoid robot model
@@ -45,17 +41,13 @@ module hpp
     /// \param robotName Name of the robot that is constructed,
     /// \param rootJointType type of root joint among "anchor", "freeflyer",
     /// "planar",
-    /// \param packageName Name of the ROS package containing the model,
-    /// \param modelName Name of the package containing the model
-    /// \param urdfSuffix suffix for urdf file,
-    ///
-    /// The ros url are built as follows:
-    /// - \c package://${packageName}/urdf/${modelName}${urdfSuffix}.urdf
-    /// - \c package://${packageName}/srdf/${modelName}${srdfSuffix}.srdf
+    /// \param urdfName name of the urdf file. It may contain
+    ///        "file://", or "package://" prefixes.
+    /// \param srdfName name of the srdf file. It may contain
+    ///        "file://", or "package://" prefixes.
     ///
     void loadHumanoidModel (in string robotName, in string rootJointType,
-			    in string packageName, in string modelName,
-			    in string urdfSuffix, in string srdfSuffix)
+			    in string urdfName, in string srdfName)
       raises (Error);
 
     ///  Load robot model

--- a/src/hpp/corbaserver/problem_solver.py
+++ b/src/hpp/corbaserver/problem_solver.py
@@ -16,6 +16,8 @@
 # hpp-corbaserver.  If not, see
 # <http://www.gnu.org/licenses/>.
 
+import warnings
+
 def newProblem (client = None, name = None):
     if client is None:
         from hpp.corbaserver import Client
@@ -174,20 +176,31 @@ class ProblemSolver (object):
     # \{
 
     ## Load obstacle from urdf file
-    #  \param package Name of the package containing the model,
-    #  \param filename name of the urdf file in the package
-    #         (without suffix .urdf)
+    #  \param filename name of the urdf file possibly including "package://"
     #  \param prefix prefix added to object names in case the same file is
     #         loaded several times
     #
-    #  The ros url is built as follows:
-    #  "package://${package}/urdf/${filename}.urdf"
-    #
     #  The kinematic structure of the urdf file is ignored. Only the geometric
     #  objects are loaded as obstacles.
-    def loadObstacleFromUrdf (self, package, filename, prefix):
-        return self.hppcorba.obstacle.loadObstacleModel (package, filename,
-                                                       prefix)
+    def loadObstacleFromUrdf (self, *args):
+        if len (args) == 3:
+            # deprecated
+            warnings.warn (\
+                """this method now takes as arguments
+                     - a urdf filename possibly including "package://",
+                     - a prefix
+                """)
+
+            package, filename, prefix = args
+            urdfFilename = "package://" + package + "/urdf/" + filename + \
+                           ".urdf"
+
+        elif len (args) == 2:
+            urdfFilename, prefix = args
+        else:
+            raise RuntimeError ("This method takes 2 arguments")
+
+        return self.hppcorba.obstacle.loadObstacleModel (urdfFilename, prefix)
 
     ## Remove an obstacle from outer objects of a joint body
     #
@@ -766,7 +779,7 @@ class ProblemSolver (object):
     #        If connectedComponentId is negative, function goes through all
     #        connected components looking for the nearest node (configuration).
     # \param distance returns the one-dimensional distance between \param config and
-    #        computed nearest node (configuration). 
+    #        computed nearest node (configuration).
     # \sa numberConnectedComponents
     def getNearestConfig (self, randomConfig, connectedComponentId = -1):
         return self.hppcorba.problem.getNearestConfig (randomConfig, connectedComponentId)

--- a/src/hpp/corbaserver/robot.py
+++ b/src/hpp/corbaserver/robot.py
@@ -61,14 +61,36 @@ class Robot (object):
             self.rankInVelocity [j] = rankInVelocity
             rankInVelocity += self.hppcorba.robot.getJointNumberDof (j)
 
+    ## Return urdf and srdf filenames
+    #
+    def urdfSrdfFilenames (self):
+        # if packageName, urdfName, urdfSuffix, srdfSuffix are members of the
+        # class, build urdf and srdf filenames
+        if hasattr (self, 'packageName') and hasattr (self,  'urdfName') and \
+           hasattr (self, 'urdfSuffix') and hasattr (self,  'srdfSuffix') :
+            urdfFilename = self.urdfPath ()
+            srdfFilename = self.srdfPath ()
+        elif hasattr (self, 'urdfFilename') and hasattr (self, 'srdfFilename') :
+            urdfFilename = self.urdfFilename
+            srdfFilename = self.srdfFilename
+        else :
+            raise RuntimeError (\
+            """instance should have one of the following sets of members
+            - (packageName, urdfName, urdfSuffix, srdfSuffix),
+            - (urdfFilename, srdfFilename)""")
+        return urdfFilename, srdfFilename
+
     def loadModel (self, robotName, rootJointType):
-        self.hppcorba.robot.loadRobotModel (robotName, rootJointType,
-                                          self.packageName, self.urdfName,
-                                          self.urdfSuffix, self.srdfSuffix)
+        urdfFilename, srdfFilename = self.urdfSrdfFilenames ()
+        self.hppcorba.robot.loadRobotModel \
+            (robotName, rootJointType, urdfFilename, srdfFilename)
         self.rebuildRanks()
 
     def urdfPath (self):
         return "package://" + self.packageName + '/urdf/' + self.urdfName + self.urdfSuffix + '.urdf'
+
+    def srdfPath (self):
+        return "package://" + self.packageName + '/srdf/' + self.urdfName + self.srdfSuffix + '.srdf'
 
     ## \name Degrees of freedom
     #  \{
@@ -441,9 +463,9 @@ class HumanoidRobot (Robot, StaticStabilityConstraintsFactory):
         Robot.__init__ (self, robotName, rootJointType, load, client)
 
     def loadModel (self, robotName, rootJointType):
-        self.hppcorba.robot.loadHumanoidModel (robotName, rootJointType,
-                                          self.packageName, self.urdfName,
-                                          self.urdfSuffix, self.srdfSuffix)
+        urdfFilename, srdfFilename = self.urdfSrdfFilenames ()
+        self.hppcorba.robot.loadHumanoidModel \
+            (robotName, rootJointType, urdfFilename, srdfFilename)
         self.rebuildRanks()
 
 class RobotXML (Robot):

--- a/src/obstacle.impl.cc
+++ b/src/obstacle.impl.cc
@@ -44,20 +44,30 @@ namespace hpp
         return server_->problemSolver();
       }
 
-      void Obstacle::loadObstacleModel (const char* package,
-					const char* file,
+      void Obstacle::loadObstacleModel (const char* filename,
 					const char* prefix)
 	throw (hpp::Error)
       {
 	try {
-          std::string pkg (package);
           DevicePtr_t device (Device::create (prefix));
-          if (pkg.empty())
-            hpp::pinocchio::urdf::loadModelFromString (
-                device, 0, "", "anchor", file, "");
-          else
-            hpp::pinocchio::urdf::loadUrdfModel (
-                device, "anchor", pkg, file);
+          hpp::pinocchio::urdf::loadModel (device, 0, "", "anchor", filename,
+                                           "");
+          device->controlComputation(hpp::pinocchio::JOINT_POSITION);
+
+          problemSolver()->addObstacle (device, true, true);
+	} catch (const std::exception& exc) {
+	  throw hpp::Error (exc.what ());
+	}
+      }
+
+      void Obstacle::loadObstacleModelFromString (const char* urdfString,
+                                                  const char* prefix)
+	throw (hpp::Error)
+      {
+	try {
+          DevicePtr_t device (Device::create (prefix));
+          hpp::pinocchio::urdf::loadModelFromString
+            (device, 0, "", "anchor", urdfString, "");
           device->controlComputation(hpp::pinocchio::JOINT_POSITION);
 
           problemSolver()->addObstacle (device, true, true);

--- a/src/obstacle.impl.hh
+++ b/src/obstacle.impl.hh
@@ -13,7 +13,7 @@
 # include <map>
 # include <string>
 
-#include <hpp/fcl/math/vec_3f.h>
+#include <hpp/fcl/data_types.h>
 
 # include <hpp/core/problem-solver.hh>
 # include <hpp/corbaserver/fwd.hh>
@@ -37,10 +37,12 @@ namespace hpp
           server_ = server;
         }
 
-	virtual void loadObstacleModel (const char* package,
-					const char* filename,
-					const char* prefix)
+	virtual void loadObstacleModel (const char* filename,
+                                                  const char* prefix)
 	  throw (hpp::Error);
+
+        virtual void loadObstacleModelFromString
+        (const char* urdfString, const char* prefix) throw (hpp::Error);
 
 	virtual void removeObstacleFromJoint
 	(const char* objectName, const char* jointName, Boolean collision,

--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -140,21 +140,17 @@ namespace hpp
       // --------------------------------------------------------------------
 
       void Robot::loadRobotModel(const char* robotName,
-				 const char* rootJointType,
-				 const char* packageName,
-				 const char* modelName,
-				 const char* urdfSuffix,
-				 const char* srdfSuffix) throw (hpp::Error)
+                                 const char* rootJointType,
+                                 const char* urdfName,
+                                 const char* srdfName) throw (hpp::Error)
       {
 	try {
 	  pinocchio::DevicePtr_t device
             (problemSolver ()->createRobot (robotName));
-	  hpp::pinocchio::urdf::loadRobotModel (device,
-					    std::string (rootJointType),
-					    std::string (packageName),
-					    std::string (modelName),
-					    std::string (urdfSuffix),
-					    std::string (srdfSuffix));
+	  hpp::pinocchio::urdf::loadModel (device, 0, "",
+                                           std::string (rootJointType),
+                                           std::string (urdfName),
+                                           std::string (srdfName));
 	  // Add device to the planner
 	  problemSolver()->robot (device);
 	  problemSolver()->robot ()->controlComputation
@@ -168,21 +164,17 @@ namespace hpp
       // --------------------------------------------------------------------
 
       void Robot::loadHumanoidModel(const char* robotName,
-				     const char* rootJointType,
-				     const char* packageName,
-				     const char* modelName,
-				     const char* urdfSuffix,
-				     const char* srdfSuffix) throw (hpp::Error)
+                                    const char* rootJointType,
+                                    const char* urdfName,
+                                    const char* srdfName) throw (hpp::Error)
       {
 	try {
 	  pinocchio::HumanoidRobotPtr_t robot
 	    (pinocchio::HumanoidRobot::create (robotName));
-	  hpp::pinocchio::urdf::loadRobotModel (robot,
-					        std::string (rootJointType),
-					        std::string (packageName),
-					        std::string (modelName),
-					        std::string (urdfSuffix),
-					        std::string (srdfSuffix));
+	  hpp::pinocchio::urdf::loadModel (robot, 0, "",
+                                           std::string (rootJointType),
+                                           std::string (urdfName),
+                                           std::string (srdfName));
           hpp::pinocchio::urdf::setupHumanoidRobot (robot);
           // Add robot to the planner
 	  problemSolver()->robot (robot);

--- a/src/robot.impl.hh
+++ b/src/robot.impl.hh
@@ -63,17 +63,13 @@ namespace hpp
 
 	virtual void loadRobotModel (const char* robotName,
 				     const char* rootJointType,
-				     const char* packageName,
-				     const char* modelName,
-				     const char* urdfSuffix,
-				     const char* srdfSuffix) throw (hpp::Error);
+				     const char* urdfName,
+				     const char* srdfName) throw (hpp::Error);
 
 	virtual void loadHumanoidModel (const char* robotName,
 					 const char* rootJointType,
-					 const char* packageName,
-					 const char* modelName,
-					 const char* urdfSuffix,
-					 const char* srdfSuffix)
+					 const char* urdfName,
+					 const char* srdfName)
 	  throw (hpp::Error);
 
 	virtual void loadRobotModelFromString (


### PR DESCRIPTION
  - formerly, urdf and srdf files needed to be in neighbor directories:
    - package://pkg/[urdf|srdf]/.../robot[urdfSuffix|srdfSuffix].[urdf|srdf].
  - Now one filename is given for the urdf file and one filename for the srdf
    file.
Porting notes are provided in the html documentation.