### PR TITLE
Make ORB endPoint parameterizable.

### DIFF
--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -163,6 +163,7 @@ namespace hpp
 
       corba::Server<Tools>* tools_;
 
+      std::string ORBendPoint;
       std::string mainContextId_;
 
       bool multiThread_, nameService_;

--- a/src/server.cc
+++ b/src/server.cc
@@ -159,7 +159,7 @@ namespace hpp
     {
       mainContextId_ = "corbaserver";
 
-      std::string host = "";
+      std::string host = "localhost";
       int port = 13331;
       bool endPointSet = false;
       ORBendPoint = endPoint (host, port);


### PR DESCRIPTION
This fixes the issue of lost connection when a network interface goes down.

@JasonChmn when this is ready, using `hppcorbaserver --host localhost` should fix your problem.