### PR TITLE
Add a ServerManager utility context.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,7 +203,7 @@ TARGET_INCLUDE_DIRECTORIES(${LIBRARY_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
 ADD_DEPENDENCIES (${LIBRARY_NAME} generate_idl_cpp)
 ADD_DEPENDENCIES (${LIBRARY_NAME} generate_idl_python)
 
-FOREACH (FILE __init__.py quaternion.py transform.py)
+FOREACH (FILE __init__.py quaternion.py transform.py utils.py)
   PYTHON_INSTALL_ON_SITE(
     hpp ${FILE}
     )

--- a/src/hpp/utils.py
+++ b/src/hpp/utils.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2020, CNRS
+# Authors: Guilhem Saurel <guilhem.saurel@laas.fr>
+
+import os
+import subprocess
+import time
+
+
+class ServerManager:
+    """A context to ensure a server is running."""
+    def __init__(self, server):
+        self.server = server
+        subprocess.run(['killall', self.server])
+
+    def __enter__(self):
+        """Run the server in background
+
+        stdout and stderr outputs of the child process are redirected to devnull (hidden).
+        preexec_fn is used to ignore ctrl-c signal send to the main script
+        (otherwise they are forwarded to the child process)
+        """
+        self.process = subprocess.Popen(self.server,
+                                        stdout=subprocess.DEVNULL,
+                                        stderr=subprocess.DEVNULL,
+                                        preexec_fn=os.setpgrp)
+        # give it some time to start
+        time.sleep(3)
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.process.kill()

--- a/src/hpp/utils.py
+++ b/src/hpp/utils.py
@@ -8,7 +8,7 @@ import time
 
 class ServerManager:
     """A context to ensure a server is running."""
-    def __init__(self, server):
+    def __init__(self, server='hppcorbaserver'):
         self.server = server
         subprocess.run(['killall', self.server])
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,8 @@
 ADD_PYTHON_UNIT_TEST(py-robot tests/robot.py src)
 ADD_PYTHON_UNIT_TEST(py-quat tests/quat.py src)
+ADD_PYTHON_UNIT_TEST(py-utils tests/utils.py src)
+
+# robot & utils start a hppcorbaserver in a separate process.
+# They shouldn't be launched at the same time.
+SET_TESTS_PROPERTIES("py-robot" PROPERTIES RUN_SERIAL "ON")
+SET_TESTS_PROPERTIES("py-utils" PROPERTIES RUN_SERIAL "ON")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,28 @@
+"""Test the content of hpp/utils.py."""
+import os
+import unittest
+
+import omniORB
+from hpp.corbaserver import Client
+from hpp.utils import ServerManager
+
+
+class Test(unittest.TestCase):
+    def test_server_manager(self):
+        # Check that we can't instanciate a client if a server isn't running
+        with self.assertRaises(Exception):  # omniORB.CORBA._omni_sys_exc
+            Client()
+
+        # Check that we can instanciate a working client if a server is running
+        with ServerManager('../src/hppcorbaserver'):
+            client = Client()
+            client.robot.createRobot("HRP-7")
+            self.assertEqual(client.robot.getRobotName(), "HRP-7")
+
+        # Check that we can't instanciate a client anymore if the server was killed
+        with self.assertRaises(Exception):  # omniORB.CORBA._omni_sys_exc
+            Client()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This was first put in https://github.com/humanoid-path-planner/hpp-rbprm-corba/commit/ef9021deff6105f6388d2f14b101675f512aa387 but after discussions with @florent-lamiraux this can probably bu usefull in other places, like hpp-corbaserver. The py-robots test could also be re-written with this.