### PR TITLE
Update to modifications in hpp-core

### DIFF
--- a/idl/hpp/core_idl/paths.idl
+++ b/idl/hpp/core_idl/paths.idl
@@ -38,7 +38,7 @@ module hpp
     string str () raises (Error);
 
     floatSeq call (in value_type t, out boolean success) raises (Error);
-    //-> operator()
+    //-> eval
 
     floatSeq at (in value_type t, out boolean success) raises (Error);
     //* hpp::core::vector_t res (get()->outputSize());

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -2067,7 +2067,7 @@ namespace hpp
 	  }
 	  PathPtr_t path = problemSolver()->paths () [pathId];
 	  bool success;
-	  Configuration_t config = (*path) (atDistance, success);
+	  Configuration_t config = path->eval(atDistance, success);
 	  if (!success) {
 	    throw std::runtime_error ("Failed to apply constraint in path "
 				      "evaluation.");


### PR DESCRIPTION
  Replace Path::operator() by Path::eval.

Requires https://github.com/humanoid-path-planner/hpp-core/pull/237.