### PR TITLE
Specify that memory should be deallocated

### DIFF
--- a/include/hpp/corbaserver/conversions.hh
+++ b/include/hpp/corbaserver/conversions.hh
@@ -134,10 +134,12 @@ namespace hpp {
     }
 
     /// Convert CORBA comparison types to C++ comparison type.
-    constraints::ComparisonTypes_t convertComparison (ComparisonTypes_t comp);
+    constraints::ComparisonTypes_t convertComparison
+    (hpp::ComparisonTypes_t comp);
 
     /// Convert C++ comparison type to CORBA comparison types.
-    ComparisonTypes_t* convertComparison (constraints::ComparisonTypes_t comp);
+    hpp::ComparisonTypes_t* convertComparison
+    (constraints::ComparisonTypes_t comp);
 
     core::Parameter toParameter (const CORBA::Any& any);
 

--- a/include/hpp/corbaserver/conversions.hh
+++ b/include/hpp/corbaserver/conversions.hh
@@ -79,7 +79,7 @@ namespace hpp {
     {
       std::size_t len = std::distance (begin, end);
       char** nameList = Names_t::allocbuf((CORBA::ULong) len);
-      Names_t *ret = new Names_t ((CORBA::ULong) len, (CORBA::ULong) len, nameList);
+      Names_t *ret = new Names_t ((CORBA::ULong) len, (CORBA::ULong) len, nameList, true);
 
       std::size_t i = 0;
       while (begin != end) {


### PR DESCRIPTION
  when creating CORBA sequences of strings.

This pull request fixes a memory issue.