### PR TITLE
disambiguate ComparisonTypes_t

### DIFF
--- a/include/hpp/corbaserver/conversions.hh
+++ b/include/hpp/corbaserver/conversions.hh
@@ -134,10 +134,10 @@ namespace hpp {
     }
 
     /// Convert CORBA comparison types to C++ comparison type.
-    constraints::ComparisonTypes_t convertComparison (ComparisonTypes_t comp);
+    constraints::ComparisonTypes_t convertComparison (hpp::ComparisonTypes_t comp);
 
     /// Convert C++ comparison type to CORBA comparison types.
-    ComparisonTypes_t* convertComparison (constraints::ComparisonTypes_t comp);
+    hpp::ComparisonTypes_t* convertComparison (constraints::ComparisonTypes_t comp);
 
     core::Parameter toParameter (const CORBA::Any& any);
 


### PR DESCRIPTION
Without this, hpp-rbprm-corba build fails with:

```
FAILED: src/CMakeFiles/rbprm-corba.dir/rbprmbuilder.impl.cc.o
/usr/lib/ccache/bin/g++ -DBOOST_ALL_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_MPL_LIMIT_LIST_SIZE=30 -DBOOST_MPL_LIMIT_VECTOR_SIZE=30 -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_THREAD_DYN_LINK -DCURVES_WITH_PINOCCHIO_SUPPORT -DHPP_FCL_HAS_OCTOMAP -DHPP_FCL_HAVE_OCTOMAP -DOCTOMAP_MAJOR_VERSION=1 -DOCTOMAP_MINOR_VERSION=9 -DOCTOMAP_PATCH_VERSION=6 -DPINOCCHIO_WITH_HPP_FCL -DPINOCCHIO_WITH_URDFDOM -Drbprm_corba_EXPORTS -I. -Iinclude -I../include -Isrc -isystem /usr/include/cddlib -isystem $ROBOTPKG/install/include -isystem /usr/include/eigen3 -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings -Wconversion -fdiagnostics-color=always -fPIC -D__x86_64__ -D__linux__ -D__OSVERSION__=2 -MD -MT src/CMakeFiles/rbprm-corba.dir/rbprmbuilder.impl.cc.o -MF src/CMakeFiles/rbprm-corba.dir/rbprmbuilder.impl.cc.o.d -o src/CMakeFiles/rbprm-corba.dir/rbprmbuilder.impl.cc.o -c ../src/rbprmbuilder.impl.cc
Dans le fichier inclus depuis ../src/rbprmbuilder.impl.cc:41:
$ROBOTPKG/install/include/hpp/corbaserver/conversions.hh:137:55: erreur: la référence à « ComparisonTypes_t » est ambiguë
  137 |     constraints::ComparisonTypes_t convertComparison (ComparisonTypes_t comp);
      |                                                       ^~~~~~~~~~~~~~~~~
Dans le fichier inclus depuis $ROBOTPKG/install/include/hpp/core/problem-solver.hh:27,
                 depuis ../src/rbprmbuilder.impl.hh:21,
                 depuis ../src/rbprmbuilder.impl.cc:21:
$ROBOTPKG/install/include/hpp/core/fwd.hh:78:44: note: les candidats sont : « typedef hpp::constraints::ComparisonTypes_t hpp::core::ComparisonTypes_t »
   78 |     typedef constraints::ComparisonTypes_t ComparisonTypes_t;
      |                                            ^~~~~~~~~~~~~~~~~
Dans le fichier inclus depuis src/hpp/corbaserver/rbprm/rbprmbuilder-idl.hh:23,
                 depuis ../src/rbprmbuilder.impl.cc:20:
$ROBOTPKG/install/include/hpp/common-idl.hh:1024:9: note:                      « class hpp::ComparisonTypes_t »
 1024 |   class ComparisonTypes_t : public _CORBA_Unbounded_Sequence_w_FixSizeElement< ComparisonType, 4, 4 >  {
      |         ^~~~~~~~~~~~~~~~~
Dans le fichier inclus depuis ../src/rbprmbuilder.impl.cc:41:
$ROBOTPKG/install/include/hpp/corbaserver/conversions.hh:140:5: erreur: la référence à « ComparisonTypes_t » est ambiguë
  140 |     ComparisonTypes_t* convertComparison (constraints::ComparisonTypes_t comp);
      |     ^~~~~~~~~~~~~~~~~
Dans le fichier inclus depuis $ROBOTPKG/install/include/hpp/core/problem-solver.hh:27,
                 depuis ../src/rbprmbuilder.impl.hh:21,
                 depuis ../src/rbprmbuilder.impl.cc:21:
$ROBOTPKG/install/include/hpp/core/fwd.hh:78:44: note: les candidats sont : « typedef hpp::constraints::ComparisonTypes_t hpp::core::ComparisonTypes_t »
   78 |     typedef constraints::ComparisonTypes_t ComparisonTypes_t;
      |                                            ^~~~~~~~~~~~~~~~~
Dans le fichier inclus depuis src/hpp/corbaserver/rbprm/rbprmbuilder-idl.hh:23,
                 depuis ../src/rbprmbuilder.impl.cc:20:
$ROBOTPKG/install/include/hpp/common-idl.hh:1024:9: note:                      « class hpp::ComparisonTypes_t »
 1024 |   class ComparisonTypes_t : public _CORBA_Unbounded_Sequence_w_FixSizeElement< ComparisonType, 4, 4 >  {
      |         ^~~~~~~~~~~~~~~~~
```