### PR TITLE
add missing include

### DIFF
--- a/src/conversions.cc
+++ b/src/conversions.cc
@@ -17,6 +17,7 @@
 #include <hpp/corbaserver/conversions.hh>
 
 #include <boost/mpl/for_each.hpp>
+#include <boost/mpl/vector.hpp>
 
 #include <pinocchio/spatial/se3.hpp>
 #include <hpp/corbaserver/config.hh>
@@ -340,7 +341,7 @@ namespace hpp {
 
           std::pair<std::string, const char*>
 
-            // This two do not work because omniidl must be given the option -Wba in order to generate 
+            // This two do not work because omniidl must be given the option -Wba in order to generate
             // a DynSK.cc file containing the conversion to/from Any type.
             , std::pair<matrix_t   , floatSeqSeq>
             , std::pair<vector_t   , floatSeq>


### PR DESCRIPTION
fix:

```
/usr/lib/ccache/bin/g++ -DBOOST_ALL_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_MPL_LIMIT_LIST_SIZE=30 -DBOOST_MPL_LIMIT_VECTOR_SIZE=30 -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_THREAD_DYN_LINK -DHPP_FCL_HAS_OCTOMAP -DHPP_FCL_HAVE_OCTOMAP -DOCTOMAP_MAJOR_VERSION=1 -DOCTOMAP_MINOR_VERSION=9 -DOCTOMAP_PATCH_VERSION=7 -DPINOCCHIO_WITH_HPP_FCL -DPINOCCHIO_WITH_URDFDOM -Dhpp_corbaserver_EXPORTS -I/home/nim/local/humanoid-path-planner/hpp-corbaserver/build -I/home/nim/local/humanoid-path-planner/hpp-corbaserver/build/include -I/home/nim/local/humanoid-path-planner/hpp-corbaserver/include -I/home/nim/local/humanoid-path-planner/hpp-corbaserver/build/src -isystem /home/nim/local/robotpkg/install/include -isystem /usr/include/eigen3 -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings -Wconversion -fdiagnostics-color=always -fPIC -D__x86_64__ -D__linux__ -D__OSVERSION__=2 -MD -MT src/CMakeFiles/hpp-corbaserver.dir/conversions.cc.o -MF src/CMakeFiles/hpp-corbaserver.dir/conversions.cc.o.d -o src/CMakeFiles/hpp-corbaserver.dir/conversions.cc.o -c /home/nim/local/humanoid-path-planner/hpp-corbaserver/src/conversions.cc
/home/nim/local/humanoid-path-planner/hpp-corbaserver/src/conversions.cc:327:29: erreur: « vector » dans l'espace de noms « boost::mpl » ne nomme pas un type de patron
  327 |         typedef boost::mpl::vector<
      |                             ^~~~~~
```