### PR TITLE
Improve static stability constraints

### DIFF
--- a/idl/hpp/corbaserver/problem.idl
+++ b/idl/hpp/corbaserver/problem.idl
@@ -283,11 +283,6 @@ module hpp
      in floatSeqSeq pts, in intSeqSeq objectTriangles,
      in intSeqSeq floorTriangles) raises (Error);
 
-    void createStaticStabilityConstraint (in string constraintName,
-     in Names_t jointNames, in floatSeqSeq points, in floatSeqSeq normals,
-     in string comRootJointName)
-      raises (Error);
-
     /// Create position constraint between two joints
     ///
     /// \param constraintName name of the constraint created,

--- a/src/hpp/corbaserver/robot.py
+++ b/src/hpp/corbaserver/robot.py
@@ -473,12 +473,15 @@ class StaticStabilityConstraintsFactory:
     ##        a full COM computations.
     ## \param leftAnkle, rightAnkle: names of the ankle joints.
     ## \param q0 input configuration for computing constraint reference,
+    ## \param maskCom mask that determines which components of the center of
+    ##        mass are constrained. For example (True, True, False) means that
+    ##        the height of the center of mass is not constrained.
     ## \return a list of the names of the created constraints
     ##
     ## The constraints are stored in the core::ProblemSolver constraints map
     ## and are accessible through the method
     ## hpp::core::ProblemSolver::addNumericalConstraint:
-    def createStaticStabilityConstraint (self, prefix, comName, leftAnkle, rightAnkle, q0):
+    def createStaticStabilityConstraint (self, prefix, comName, leftAnkle, rightAnkle, q0, maskCom = (True,)*3):
         robot = self.hppcorba.robot
         problem = self.hppcorba.problem
 
@@ -492,7 +495,7 @@ class StaticStabilityConstraintsFactory:
         # COM wrt left ankle frame
         xloc = Ml.inverse().transform(x)
         result.append (prefix + "relative-com")
-        problem.createRelativeComConstraint (result[-1], comName, leftAnkle, xloc.tolist(), (True,)*3)
+        problem.createRelativeComConstraint (result[-1], comName, leftAnkle, xloc.tolist(), maskCom)
 
         # Pose of the left foot
         result.append (prefix + "pose-left-foot")

--- a/src/problem.impl.hh
+++ b/src/problem.impl.hh
@@ -161,11 +161,6 @@ namespace hpp
          const hpp::floatSeqSeq& points, const hpp::intSeqSeq& objTriangles,
          const hpp::intSeqSeq& floorTriangles);
 
-        void createStaticStabilityConstraint (
-            const char* constraintName, const hpp::Names_t& jointNames,
-            const hpp::floatSeqSeq& points, const hpp::floatSeqSeq& normals,
-            const char* comRootJointName);
-
 	virtual void createPositionConstraint (const char* constraintName,
 					       const char* joint1Name,
 					       const char* joint2Name,


### PR DESCRIPTION
  - [python] allow to set a mask for the COM constraint,
  - [problem.idl] do not bind createStaticStabilityConstraint anymore.
 This method is better implemented in hpp-manipulation-corba.