### PR TITLE
Add getContexts and deleteContext to the main server

### DIFF
--- a/idl/hpp/corbaserver/tools.idl
+++ b/idl/hpp/corbaserver/tools.idl
@@ -31,6 +31,13 @@ module hpp
     /// whichever ProblemSolver in this map.
     boolean createContext (in string context_) raises (Error);
 
+    /// List the existing contexts.
+    Names_t getContexts () raises (Error);
+
+    /// Remove a context.
+    /// \return True if effectively deleted and False if not found.
+    boolean deleteContext (in string context_) raises (Error);
+
     /// Get a server object
     Object getServer (in string context_, in string pluginName, in string objectname) raises (Error);
 

--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -135,7 +135,7 @@ class HPP_CORBASERVER_DLLAPI Server {
   void requestShutdown(bool wait);
 
   bool createContext(const std::string& contextName);
-  
+
   std::vector<std::string> getContexts() const;
 
   bool deleteContext(const std::string& contextName);

--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -135,6 +135,10 @@ class HPP_CORBASERVER_DLLAPI Server {
   void requestShutdown(bool wait);
 
   bool createContext(const std::string& contextName);
+  
+  std::vector<std::string> getContexts() const;
+
+  bool deleteContext(const std::string& contextName);
 
   CORBA::Object_ptr getServer(const std::string& contextName,
                               const std::string& pluginName,

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -2391,9 +2391,7 @@ hpp::core_idl::Path_ptr Problem::getPath(ULong pathId) {
 ULong Problem::addPath(hpp::core_idl::PathVector_ptr _path) {
   core::PathVectorPtr_t path;
   try {
-    core::PathPtr_t p =
-        reference_to_object<core::Path>(server_->parent(), _path);
-    path = HPP_DYNAMIC_PTR_CAST(core::PathVector, p);
+    path = reference_to_object<core::PathVector> (server_->parent(), _path);
   } catch (const Error& e) {
     // TODO in this case, we should define a distance from the CORBA type.
     // This would allow to implement a distance class in Python.

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -2391,7 +2391,7 @@ hpp::core_idl::Path_ptr Problem::getPath(ULong pathId) {
 ULong Problem::addPath(hpp::core_idl::PathVector_ptr _path) {
   core::PathVectorPtr_t path;
   try {
-    path = reference_to_object<core::PathVector> (server_->parent(), _path);
+    path = reference_to_object<core::PathVector>(server_->parent(), _path);
   } catch (const Error& e) {
     // TODO in this case, we should define a distance from the CORBA type.
     // This would allow to implement a distance class in Python.

--- a/src/server.cc
+++ b/src/server.cc
@@ -97,24 +97,23 @@ class Tools : public virtual POA_hpp::Tools {
     }
   }
 
-  virtual Names_t* getContexts () {
+  virtual Names_t* getContexts() {
     try {
-      std::vector<std::string> contexts (server_->getContexts());
+      std::vector<std::string> contexts(server_->getContexts());
       return toNames_t(contexts);
     } catch (const std::exception& e) {
       throw hpp::Error(e.what());
     }
   }
 
-  bool deleteContext (const char* context)
-  {
+  bool deleteContext(const char* context) {
     try {
       std::string c(context);
       return server_->deleteContext(c);
     } catch (const std::exception& e) {
       throw hpp::Error(e.what());
     }
-    }
+  }
 
   CORBA::Object_ptr getServer(const char* contextName, const char* pluginName,
                               const char* objectName) {
@@ -262,8 +261,7 @@ bool Server::createContext(const std::string& name) {
 std::vector<std::string> Server::getContexts() const {
   std::vector<std::string> contexts;
   contexts.reserve(contexts_.size());
-  for (auto const pair : contexts_)
-    contexts.push_back(pair.first);
+  for (auto const pair : contexts_) contexts.push_back(pair.first);
   return contexts;
 }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -45,6 +45,7 @@
 #include <iostream>
 
 #include "basic-server.hh"
+#include "hpp/corbaserver/conversions.hh"
 #include "hpp/corbaserver/servant-base.hh"
 #include "hpp/corbaserver/tools-idl.hh"
 
@@ -95,6 +96,25 @@ class Tools : public virtual POA_hpp::Tools {
       throw hpp::Error(e.what());
     }
   }
+
+  virtual Names_t* getContexts () {
+    try {
+      std::vector<std::string> contexts (server_->getContexts());
+      return toNames_t(contexts);
+    } catch (const std::exception& e) {
+      throw hpp::Error(e.what());
+    }
+  }
+
+  bool deleteContext (const char* context)
+  {
+    try {
+      std::string c(context);
+      return server_->deleteContext(c);
+    } catch (const std::exception& e) {
+      throw hpp::Error(e.what());
+    }
+    }
 
   CORBA::Object_ptr getServer(const char* contextName, const char* pluginName,
                               const char* objectName) {
@@ -237,6 +257,18 @@ bool Server::createContext(const std::string& name) {
 
   getContext(name);
   return true;
+}
+
+std::vector<std::string> Server::getContexts() const {
+  std::vector<std::string> contexts;
+  contexts.reserve(contexts_.size());
+  for (auto const pair : contexts_)
+    contexts.push_back(pair.first);
+  return contexts;
+}
+
+bool Server::deleteContext(const std::string& name) {
+  return static_cast<bool>(contexts_.erase(name));
 }
 
 core::ProblemSolverPtr_t Server::problemSolver() {


### PR DESCRIPTION
This PR adds the functions that sit next to `createContext`, that allows to work on several problems in parallel. The behavior of the new functions should be clear given their names.

While here, I add a commit which was on my devel branch when I left LAAS. I don't remember why I did that (the original commit is 1 year and 7 months ago...)