### PR TITLE
Fix how hppcorbaserver is killed in ServerManager

### DIFF
--- a/src/hpp/utils.py
+++ b/src/hpp/utils.py
@@ -38,4 +38,7 @@ class ServerManager:
     def __exit__(self, exc_type, exc_value, exc_traceback):
         tool = hpp.corbaserver.tools.Tools()
         tool.shutdown()
+        # Give some time to HPP to properly shutdown.
+        time.sleep(1)
+        # Once HPP process is stopped, this removes the defunct process. 
         self.process.communicate()

--- a/src/hpp/utils.py
+++ b/src/hpp/utils.py
@@ -40,5 +40,5 @@ class ServerManager:
         tool.shutdown()
         # Give some time to HPP to properly shutdown.
         time.sleep(1)
-        # Once HPP process is stopped, this removes the defunct process. 
+        # Once HPP process is stopped, this removes the defunct process.
         self.process.communicate()

--- a/src/hpp/utils.py
+++ b/src/hpp/utils.py
@@ -4,6 +4,7 @@
 import os
 import subprocess
 import time
+import hpp.corbaserver
 
 try:
     from subprocess import DEVNULL, run
@@ -35,4 +36,6 @@ class ServerManager:
         time.sleep(3)
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.process.kill()
+        tool = hpp.corbaserver.tools.Tools()
+        tool.shutdown()
+        self.process.communicate()


### PR DESCRIPTION
Fixes #178

This code now works:

```python
from hpp.utils import ServerManager
import hpp.corbaserver

with ServerManager():
    cl1 = hpp.corbaserver.Client()

with ServerManager():
    cl2 = hpp.corbaserver.Client()
```