### PR TITLE
Better handle default port

### DIFF
--- a/src/hpp/corbaserver/client.py
+++ b/src/hpp/corbaserver/client.py
@@ -24,7 +24,7 @@ class Client:
     """
     Connect and create clients for all HPP services.
     """
-
+    defaultPort = 13331
     defaultClients = {
         "problem": hpp_idl.hpp.corbaserver.Problem,
         "obstacle": hpp_idl.hpp.corbaserver.Obstacle,
@@ -135,7 +135,7 @@ class Client:
                 service="NameService", host=host, port=port, default_port=2809
             )
             urlHppTools = _getIIOPurl(
-                service="hpp-corbaserver", host=host, port=port, default_port=13331
+                service="hpp-corbaserver", host=host, port=port, default_port=self.defaultPort
             )
             try:
                 self.initWithDirectLink(urlHppTools)
@@ -159,7 +159,7 @@ def _getIIOPurl(service="NameService", host=None, port=None, default_port=None):
     - use default values ("localhost", 2809)
     """
     _host = "localhost"
-    _port = 2809
+    _port = None
     import os
 
     try:

--- a/src/hpp/corbaserver/client.py
+++ b/src/hpp/corbaserver/client.py
@@ -132,10 +132,11 @@ class Client:
                     self.initWithNameService(url + "/NameService")
         else:
             urlNameService = _getIIOPurl(
-                service="NameService", host=host, port=port if port else 2809
+                service="NameService", host=host, port=port, default_port = 2809
             )
             urlHppTools = _getIIOPurl(
-                service="hpp-corbaserver", host=host, port=port if port else 13331
+                service="hpp-corbaserver", host=host, port=port,
+                default_port = 13331
             )
             try:
                 self.initWithDirectLink(urlHppTools)
@@ -150,7 +151,7 @@ class Client:
             self._makeClient(serviceId, serviceName, class_, context)
 
 
-def _getIIOPurl(service="NameService", host=None, port=None):
+def _getIIOPurl(service="NameService", host=None, port=None, default_port=None):
     """
     Returns "corbaloc:iiop:<host>:<port>/NameService"
     where host and port are, in this order of priority:
@@ -178,6 +179,8 @@ def _getIIOPurl(service="NameService", host=None, port=None):
         _host = host
     if port:
         _port = port
+    if _port is None:
+        _port = default_port
     if _host is None and _port is None:
         url = "corbaloc:iiop:"
     else:

--- a/src/hpp/corbaserver/client.py
+++ b/src/hpp/corbaserver/client.py
@@ -132,11 +132,10 @@ class Client:
                     self.initWithNameService(url + "/NameService")
         else:
             urlNameService = _getIIOPurl(
-                service="NameService", host=host, port=port, default_port = 2809
+                service="NameService", host=host, port=port, default_port=2809
             )
             urlHppTools = _getIIOPurl(
-                service="hpp-corbaserver", host=host, port=port,
-                default_port = 13331
+                service="hpp-corbaserver", host=host, port=port, default_port=13331
             )
             try:
                 self.initWithDirectLink(urlHppTools)

--- a/src/hpp/corbaserver/client.py
+++ b/src/hpp/corbaserver/client.py
@@ -24,6 +24,7 @@ class Client:
     """
     Connect and create clients for all HPP services.
     """
+
     defaultPort = 13331
     defaultClients = {
         "problem": hpp_idl.hpp.corbaserver.Problem,
@@ -135,7 +136,10 @@ class Client:
                 service="NameService", host=host, port=port, default_port=2809
             )
             urlHppTools = _getIIOPurl(
-                service="hpp-corbaserver", host=host, port=port, default_port=self.defaultPort
+                service="hpp-corbaserver",
+                host=host,
+                port=port,
+                default_port=self.defaultPort,
             )
             try:
                 self.initWithDirectLink(urlHppTools)

--- a/src/hpp/corbaserver/tools.py
+++ b/src/hpp/corbaserver/tools.py
@@ -1,13 +1,13 @@
 import sys
 
 import hpp_idl.hpp as _hpp
-
+from .client import Client
 
 def loadServerPlugin(context, plugin, url=None, port=None):
     if port is None:
         import os
 
-        port = os.getenv("HPP_PORT", 13331)
+        port = os.getenv('HPP_PORT', Client.defaultPort)
     client = Tools(url, port=port)
     return client.loadServerPlugin(context, plugin)
 
@@ -16,7 +16,7 @@ if sys.version_info.major > 2:
     loadServerPlugin.__doc__ = _hpp.Tools.loadServerPlugin__doc__
 
 
-def createContext(context, url=None, port=13331):
+def createContext(context, url=None, port=Client.defaultPort):
     client = Tools(url, port=port)
     return client.createContext(context)
 
@@ -25,7 +25,7 @@ if sys.version_info.major > 2:
     createContext.__doc__ = _hpp.Tools.createContext__doc__
 
 
-def Tools(url=None, port=13331):
+def Tools(url=None, port=Client.defaultPort):
     from .client import Client
 
     _tc = Client(url=url, clients={}, port=port)

--- a/src/hpp/corbaserver/tools.py
+++ b/src/hpp/corbaserver/tools.py
@@ -3,7 +3,10 @@ import sys
 import hpp_idl.hpp as _hpp
 
 
-def loadServerPlugin(context, plugin, url=None, port=13331):
+def loadServerPlugin(context, plugin, url=None, port=None):
+    if port is None:
+        import os
+        port = os.getenv('HPP_PORT', 13331)
     client = Tools(url, port=port)
     return client.loadServerPlugin(context, plugin)
 

--- a/src/hpp/corbaserver/tools.py
+++ b/src/hpp/corbaserver/tools.py
@@ -6,7 +6,8 @@ import hpp_idl.hpp as _hpp
 def loadServerPlugin(context, plugin, url=None, port=None):
     if port is None:
         import os
-        port = os.getenv('HPP_PORT', 13331)
+
+        port = os.getenv("HPP_PORT", 13331)
     client = Tools(url, port=port)
     return client.loadServerPlugin(context, plugin)
 

--- a/src/hpp/corbaserver/tools.py
+++ b/src/hpp/corbaserver/tools.py
@@ -3,11 +3,12 @@ import sys
 import hpp_idl.hpp as _hpp
 from .client import Client
 
+
 def loadServerPlugin(context, plugin, url=None, port=None):
     if port is None:
         import os
 
-        port = os.getenv('HPP_PORT', Client.defaultPort)
+        port = os.getenv("HPP_PORT", Client.defaultPort)
     client = Tools(url, port=port)
     return client.loadServerPlugin(context, plugin)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,5 +9,4 @@ set_tests_properties("py-robot" PROPERTIES RUN_SERIAL "ON")
 set_tests_properties("py-utils" PROPERTIES RUN_SERIAL "ON")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hppcorbaserver.sh
-  ${CMAKE_CURRENT_BINARY_DIR}/hppcorbaserver.sh
-  )
+               ${CMAKE_CURRENT_BINARY_DIR}/hppcorbaserver.sh)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,13 @@
 add_python_unit_test(py-robot tests/robot.py src)
 add_python_unit_test(py-quat tests/quat.py src)
 add_python_unit_test(py-utils tests/utils.py src)
+add_python_unit_test(py-port tests/port.py src)
 
 # robot & utils start a hppcorbaserver in a separate process. They shouldn't be
 # launched at the same time.
 set_tests_properties("py-robot" PROPERTIES RUN_SERIAL "ON")
 set_tests_properties("py-utils" PROPERTIES RUN_SERIAL "ON")
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hppcorbaserver.sh
+  ${CMAKE_CURRENT_BINARY_DIR}/hppcorbaserver.sh
+  )

--- a/tests/hppcorbaserver.sh
+++ b/tests/hppcorbaserver.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export HPP_PORT=13332
+../src/hppcorbaserver

--- a/tests/port.py
+++ b/tests/port.py
@@ -24,15 +24,16 @@ class Test(unittest.TestCase):
         )
         # give it some time to start
         time.sleep(3)
-        
+
         client = Client(port=13332)
         client.robot.createRobot("HRP-7")
         self.assertEqual(client.robot.getRobotName(), "HRP-7")
-        os.environ['HPP_PORT'] = '13332'
+        os.environ["HPP_PORT"] = "13332"
         client = Client()
         self.assertEqual(client.robot.getRobotName(), "HRP-7")
         self.process.terminate()
         run(["killall", "hppcorbaserver"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/port.py
+++ b/tests/port.py
@@ -1,0 +1,38 @@
+"""Test running hppcorbaserver on another port."""
+import unittest
+
+import os, time
+from hpp.corbaserver import Client
+import subprocess
+from subprocess import DEVNULL, run
+
+
+class Test(unittest.TestCase):
+    def test_server_manager(self):
+        """Run the server in background on port 13332
+
+        stdout and stderr outputs of the child process are redirected to devnull.
+        preexec_fn is used to ignore ctrl-c signal send to the main script
+        (otherwise they are forwarded to the child process)
+        """
+        # Check that we can't instanciate a client if a server isn't running
+        with self.assertRaises(Exception):  # omniORB.CORBA._omni_sys_exc
+            Client(port=13332)
+
+        self.process = subprocess.Popen(
+            "./hppcorbaserver.sh", stdout=DEVNULL, stderr=DEVNULL, preexec_fn=os.setpgrp
+        )
+        # give it some time to start
+        time.sleep(3)
+        
+        client = Client(port=13332)
+        client.robot.createRobot("HRP-7")
+        self.assertEqual(client.robot.getRobotName(), "HRP-7")
+        os.environ['HPP_PORT'] = '13332'
+        client = Client()
+        self.assertEqual(client.robot.getRobotName(), "HRP-7")
+        self.process.terminate()
+        run(["killall", "hppcorbaserver"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  When creating a client, environment variable HPP_PORT was not really
  taken into account. This commit fixes this issue and allows to control
  parallel instances of hppcorbaserver on different ports only by specifying
  variable HPP_PORT.