### PR TITLE
avoid throwing an exception with deleting twice a servant.

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -139,6 +139,14 @@ class Tools : public virtual POA_hpp::Tools {
       server_->poa()->deactivate_object(objectId.in());
     } catch (const std::exception& e) {
       throw hpp::Error(e.what());
+    } catch (PortableServer::POA::ObjectNotActive const& e) {
+      // This allows to call `deleteServant` twice on the
+      // same object. OmniORB and Python does not offer a nice mechanism
+      // to avoid calling this method twice. We simply warn because
+      // there should be no harm in continuing the program since
+      // the request was to delete an object which has already been
+      // deleted.
+      hppDout(warning, "Trying to delete an non existant servant. Object not active: " << id);
     }
   }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -146,7 +146,9 @@ class Tools : public virtual POA_hpp::Tools {
       // there should be no harm in continuing the program since
       // the request was to delete an object which has already been
       // deleted.
-      hppDout(warning, "Trying to delete an non existant servant. Object not active: " << id);
+      hppDout(warning,
+              "Trying to delete an non existant servant. Object not active: "
+                  << id);
     }
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_python_unit_test(py-utils tests/utils.py src)
 if(PYTHON_VERSION_MAJOR EQUAL 3)
   add_python_unit_test(py-port tests/port.py src)
 endif()
+add_python_unit_test(py-delete-servant tests/delete_servant.py src)
 
 # robot & utils start a hppcorbaserver in a separate process. They shouldn't be
 # launched at the same time.

--- a/tests/delete_servant.py
+++ b/tests/delete_servant.py
@@ -5,6 +5,7 @@ from hpp.corbaserver import Client
 from hpp.corbaserver.tools import Tools
 from hpp.utils import ServerManager
 
+
 class Test(unittest.TestCase):
     def test_delete_servant_from_object_twice(self):
         with ServerManager("../src/hppcorbaserver"):

--- a/tests/delete_servant.py
+++ b/tests/delete_servant.py
@@ -1,0 +1,17 @@
+"""Test deleting twice the same object does not throw."""
+import unittest
+
+from hpp.corbaserver import Client
+from hpp.corbaserver.tools import Tools
+from hpp.utils import ServerManager
+
+class Test(unittest.TestCase):
+    def test_delete_servant_from_object_twice(self):
+        with ServerManager("../src/hppcorbaserver"):
+            self.client = Client()
+            self.client.robot.createRobot("name")
+            obj = self.client.problem.getProblem()
+            self.tools = Tools()
+            self.tools.deleteServantFromObject(obj)
+            # This one should not throw
+            self.tools.deleteServantFromObject(obj)


### PR DESCRIPTION
When an Python CORBA object is `wrap_delete` twice, after one of the two is deleted by Python, the corresponding servant in C++ gets deleted. When the second is deleted, an exception is raised. Sadly, at the moment, in Python, it is not possible to count the number of reference to a C++ servant so it is hard to avoid such situation.

This PR bypasses the issue by not raising an error when trying to delete an already deleted object. This should be safe since there is semantically no work to do to delete an already deleted object.

Another possible solution is to catch the exception in the `_Deleter` class in Python.