### PR TITLE
test: run py-port in serial

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_python_unit_test(py-problem tests/problem.py src)
 # launched at the same time.
 set_tests_properties("py-robot" PROPERTIES RUN_SERIAL "ON")
 set_tests_properties("py-utils" PROPERTIES RUN_SERIAL "ON")
+set_tests_properties("py-port" PROPERTIES RUN_SERIAL "ON")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hppcorbaserver.sh
                ${CMAKE_CURRENT_BINARY_DIR}/hppcorbaserver.sh)


### PR DESCRIPTION
because CI gets a very high rate of
> omniORB.CORBA._omni_sys_exc: CORBA.TRANSIENT(omniORB.TRANSIENT_ConnectFailed, CORBA.COMPLETED_NO)