### PR TITLE
Add CLI arguments to toggle logging.

### DIFF
--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -91,20 +91,6 @@ class HPP_CORBASERVER_DLLAPI Server {
          bool multiThread = false);
 
   /// Constructor
-  /// \param problemSolverMap the object that will handle Corba requests.
-  /// \param argc, argv parameter to feed ORB initialization.
-  /// \param multiThread whether the server may process request using
-  ///        multithred policy.
-  /// \note It is recommended to configure your Corba implementation
-  ///       through environment variables and to set argc to 1 and argv to
-  ///       any string.
-  /// \note It is highly recommended not to enable multi-thread policy in
-  ///       CORBA request processing if this library is run from an openGL
-  ///       based GUI, since OpenGL does not support multithreading.
-  Server(ProblemSolverMapPtr_t problemSolverMap, int argc, const char* argv[],
-         bool multiThread = false);
-
-  /// Constructor
   /// \param problemSolver the object that will handle Corba requests.
   /// \param multiThread whether the server may process request using
   ///        multithred policy.

--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -104,6 +104,24 @@ class HPP_CORBASERVER_DLLAPI Server {
   Server(ProblemSolverMapPtr_t problemSolverMap, int argc, const char* argv[],
          bool multiThread = false);
 
+  /// Constructor
+  /// \param problemSolver the object that will handle Corba requests.
+  /// \param multiThread whether the server may process request using
+  ///        multithred policy.
+  Server(core::ProblemSolverPtr_t problemSolver, bool multiThread = false);
+
+  ///\name CORBA server initialization
+  /// \{
+
+  /// Configure using command line argument
+  bool parseArguments(int argc, const char* argv[]);
+
+  /// Initialize ORB and CORBA servers.
+  void initialize();
+
+  /// \}
+
+
   /// \brief Shutdown CORBA server
   ~Server();
 
@@ -166,14 +184,6 @@ class HPP_CORBASERVER_DLLAPI Server {
   void clearServantsMap();
 
  private:
-  ///\name CORBA server initialization
-  /// \{
-  /// Initialize ORB and CORBA servers.
-
-  void parseArguments(int argc, const char* argv[]);
-
-  /// \}
-
   corba::Server<Tools>* tools_;
 
   std::string ORBendPoint;

--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -107,7 +107,6 @@ class HPP_CORBASERVER_DLLAPI Server {
 
   /// \}
 
-
   /// \brief Shutdown CORBA server
   ~Server();
 

--- a/src/hpp-corbaserver.cc
+++ b/src/hpp-corbaserver.cc
@@ -40,7 +40,12 @@
 using hpp::corbaServer::Server;
 
 int main(int argc, const char* argv[]) {
-  Server server(hpp::core::ProblemSolver::create(), argc, argv, true);
+  Server server(hpp::core::ProblemSolver::create(), true);
+
+  if (!server.parseArguments(argc, argv)) {
+    return 1;
+  }
+  server.initialize();
 
   server.startCorbaServer();
   server.processRequest(true);

--- a/src/server.cc
+++ b/src/server.cc
@@ -59,10 +59,12 @@ using omniORB::fatalException;
 namespace {
 void usage(const char* app) {
   std::cerr << "Usage: " << app << " [options] ..." << '\n'
-            << "  --name <name>" << '\n'
-            << "  --help" << '\n'
-            << "  --single-thread" << '\n'
-            << "  --multi-thread" << std::endl;
+            << "  --name <name>      " << '\n'
+            << "  --help             " << '\n'
+            << "  --verbosity <level>" << '\t' << "where level is a positive integer between 0 (no logs) to 50 (very verbose)."<< '\n'
+            << "  --benchmark        " << '\t' << "enable benchmarking (written in the logs)."<< '\n'
+            << "  --single-thread    " << '\n'
+            << "  --multi-thread     " << std::endl;
 }
 
 std::string endPoint(const std::string& host, const int port) {
@@ -246,6 +248,11 @@ void Server::parseArguments(int argc, const char* argv[]) {
     } else if (strcmp(argv[i], "-ORBendPoint") == 0) {
       ORBendPoint = argv[++i];
       endPointSet = true;
+    } else if (strcmp(argv[i], "--verbosity") == 0) {
+      int verbosityLevel = atoi(argv[++i]);
+      ::hpp::debug::setVerbosityLevel(verbosityLevel);
+    } else if (strcmp(argv[i], "--benchmark") == 0) {
+      ::hpp::debug::enableBenchmark(true);
     }
   }
   if (endPointSet) std::cout << "End point: " << ORBendPoint << std::endl;

--- a/src/server.cc
+++ b/src/server.cc
@@ -58,13 +58,21 @@ using omniORB::fatalException;
 
 namespace {
 void usage(const char* app) {
-  std::cerr << "Usage: " << app << " [options] ..." << '\n'
-            << "  --name <name>      " << '\n'
-            << "  --help             " << '\n'
-            << "  --verbosity <level>" << '\t' << "where level is a positive integer between 0 (no logs) to 50 (very verbose)."<< '\n'
-            << "  --benchmark        " << '\t' << "enable benchmarking (written in the logs)."<< '\n'
-            << "  --single-thread    " << '\n'
-            << "  --multi-thread     " << std::endl;
+  std::cerr << "Usage: " << app << " [options] ...\n"
+            << "  --name <name>      \n"
+            << "  --host <host>      \n"
+            << "  --port <port>      \n"
+            << "  --help             \n"
+            << "  --verbosity <level>\twhere level is a positive integer between 0 (no logs) to 50 (very verbose).\n"
+            << "  --benchmark        \tenable benchmarking (written in the logs).\n"
+            << "  --single-thread    \n"
+            << "  --multi-thread     \n"
+            << "\n"
+               "Environment variables:\n"
+               "- HPP_LOGGINGDIR: change the directory where logs are written.\n"
+               "- HPP_HOST: change the default host.\n"
+               "- HPP_PORT: change the default port.\n"
+            << std::flush;
 }
 
 std::string endPoint(const std::string& host, const int port) {

--- a/src/server.cc
+++ b/src/server.cc
@@ -58,21 +58,23 @@ using omniORB::fatalException;
 
 namespace {
 void usage(const char* app) {
-  std::cerr << "Usage: " << app << " [options] ...\n"
-            << "  --name <name>      \n"
-            << "  --host <host>      \n"
-            << "  --port <port>      \n"
-            << "  --help             \n"
-            << "  --verbosity <level>\twhere level is a positive integer between 0 (no logs) to 50 (very verbose).\n"
-            << "  --benchmark        \tenable benchmarking (written in the logs).\n"
-            << "  --single-thread    \n"
-            << "  --multi-thread     \n"
-            << "\n"
-               "Environment variables:\n"
-               "- HPP_LOGGINGDIR: change the directory where logs are written.\n"
-               "- HPP_HOST: change the default host.\n"
-               "- HPP_PORT: change the default port.\n"
-            << std::flush;
+  std::cerr
+      << "Usage: " << app << " [options] ...\n"
+      << "  --name <name>      \n"
+      << "  --host <host>      \n"
+      << "  --port <port>      \n"
+      << "  --help             \n"
+      << "  --verbosity <level>\twhere level is a positive integer between 0 "
+         "(no logs) to 50 (very verbose).\n"
+      << "  --benchmark        \tenable benchmarking (written in the logs).\n"
+      << "  --single-thread    \n"
+      << "  --multi-thread     \n"
+      << "\n"
+         "Environment variables:\n"
+         "- HPP_LOGGINGDIR: change the directory where logs are written.\n"
+         "- HPP_HOST: change the default host.\n"
+         "- HPP_PORT: change the default port.\n"
+      << std::flush;
 }
 
 std::string endPoint(const std::string& host, const int port) {
@@ -188,9 +190,7 @@ Server::Server(core::ProblemSolverPtr_t problemSolver, int argc,
 Server::Server(core::ProblemSolverPtr_t problemSolver, bool inMultiThread)
     : multiThread_(inMultiThread),
       nameService_(false),
-      problemSolverMap_(new ProblemSolverMap(problemSolver)) {
-}
-
+      problemSolverMap_(new ProblemSolverMap(problemSolver)) {}
 
 void Server::initialize() {
   if (!nameService_) tools_->initOmniINSPOA("hpp-corbaserver");

--- a/src/server.cc
+++ b/src/server.cc
@@ -185,15 +185,6 @@ Server::Server(core::ProblemSolverPtr_t problemSolver, int argc,
   initialize();
 }
 
-Server::Server(ProblemSolverMapPtr_t problemSolverMap, int argc,
-               const char* argv[], bool inMultiThread)
-    : multiThread_(inMultiThread),
-      nameService_(false),
-      problemSolverMap_(problemSolverMap) {
-  parseArguments(argc, argv);
-  initialize();
-}
-
 Server::Server(core::ProblemSolverPtr_t problemSolver, bool inMultiThread)
     : multiThread_(inMultiThread),
       nameService_(false),


### PR DESCRIPTION
This PR needs https://github.com/humanoid-path-planner/hpp-util/pull/57.

Logs can be enabled or disabled using, e.g.,
```
hppcorbaserver --benchmark --verbosity 50
```

`hppcorbaserver --help` returns
```
Usage: hppcorbaserver [options] ...
  --name <name>      
  --host <host>      
  --port <port>      
  --help             
  --verbosity <level>	where level is a positive integer between 0 (no logs) to 50 (very verbose).
  --benchmark        	enable benchmarking (written in the logs).
  --single-thread    
  --multi-thread     

Environment variables:
- HPP_LOGGINGDIR: change the directory where logs are written.
- HPP_HOST: change the default host.
- HPP_PORT: change the default port.
```
