### PR TITLE
Expose path::Hermite + exceptions in wrap_delete

### DIFF
--- a/idl/hpp/core_idl/paths.idl
+++ b/idl/hpp/core_idl/paths.idl
@@ -87,10 +87,16 @@ module hpp
     //*   (server_, new PathVector (server_, out));
   }; // interface PathVector
 
+  module path_idl {
+    interface Hermite : Path {
+    };
+  }; // module path
+
   }; // module core
 }; // module hpp
 //* #include <hpp/core/path.hh>
 //* #include <hpp/core/path-vector.hh>
+//* #include <hpp/core/path/hermite.hh>
 //* #include <hpp/core_idl/_constraints.hh>
 
 #include <hpp/core_idl/_constraints.idl>

--- a/src/hpp/corbaserver/tools.py
+++ b/src/hpp/corbaserver/tools.py
@@ -55,12 +55,9 @@ class _Deleter:
         try:
             if not self.client:
                 from .client import Client
-
                 self.client = Client(clients={})._tools
             self.client.deleteServant(self.ostr)
-        except CORBA.TRANSIENT:
-            pass
-        except CORBA.COMM_FAILURE:
+        except CORBA.SystemException:
             pass
 
 

--- a/src/hpp/corbaserver/tools.py
+++ b/src/hpp/corbaserver/tools.py
@@ -55,6 +55,7 @@ class _Deleter:
         try:
             if not self.client:
                 from .client import Client
+
                 self.client = Client(clients={})._tools
             self.client.deleteServant(self.ostr)
         except CORBA.SystemException:


### PR DESCRIPTION
Exception raised in wrap_delete can be sometimes be CORBA.UNKNOWN. Maybe catching all CORBA exception is a bit too large though I don't know exactly what should be caught.