### PR TITLE
Pass computation flag to Device::computeForwardKinematics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ if(NOT CLIENT_ONLY)
       include/hpp/corbaserver/server.hh
       include/hpp/corbaserver/server-plugin.hh
       include/hpp/corbaserver/steering-method.hh
+      include/hpp/corbaserver/read-write-lock.hh
       include/hpp/corbaserver/conversions.hh)
 endif(NOT CLIENT_ONLY)
 

--- a/cmake-modules/omniidl/cxx_impl/template.py
+++ b/cmake-modules/omniidl/cxx_impl/template.py
@@ -206,6 +206,17 @@ void @impl_tpl_name@<_Base, _Storage>::deleteThis ()
     throw @error_type@ (e.what());
   }
 }""",
+    "deleteIfExpired": """
+template <typename _Base, typename _Storage>
+::CORBA::Boolean @impl_tpl_name@<_Base, _Storage>::deleteIfExpired ()
+{
+  try {
+    // automatically generated code.
+    return _ServantBase::deleteIfExpired();
+  } catch (const std::exception& e) {
+    throw @error_type@ (e.what());
+  }
+}""",
     "persistantStorage": """
 template <typename _Base, typename _Storage>
 void @impl_tpl_name@<_Base, _Storage>::persistantStorage (::CORBA::Boolean persistant)

--- a/cmake-modules/omniidl/cxx_impl/template.py
+++ b/cmake-modules/omniidl/cxx_impl/template.py
@@ -206,6 +206,17 @@ void @impl_tpl_name@<_Base, _Storage>::deleteThis ()
     throw @error_type@ (e.what());
   }
 }""",
+    "persistantStorage": """
+template <typename _Base, typename _Storage>
+void @impl_tpl_name@<_Base, _Storage>::persistantStorage (::CORBA::Boolean persistant)
+{
+  try {
+    // automatically generated code.
+    _ServantBase::persistantStorage(persistant);
+  } catch (const std::exception& e) {
+    throw @error_type@ (e.what());
+  }
+}""",
 }
 
 definition_object_downcast = """\

--- a/idl/hpp/common.idl
+++ b/idl/hpp/common.idl
@@ -11,7 +11,7 @@
 #ifndef HPP_COMMON_IDL
 #define HPP_COMMON_IDL
 
-#define HPP_EXPOSE_MEMORY_DEALLOCATION(ErrorType) void deleteThis() raises (ErrorType); void persistantStorage(in boolean persistant) raises (ErrorType);
+#define HPP_EXPOSE_MEMORY_DEALLOCATION(ErrorType) void deleteThis() raises (ErrorType); boolean deleteIfExpired() raises (ErrorType); void persistantStorage(in boolean persistant) raises (ErrorType);
 
 module hpp
 {

--- a/idl/hpp/common.idl
+++ b/idl/hpp/common.idl
@@ -11,7 +11,7 @@
 #ifndef HPP_COMMON_IDL
 #define HPP_COMMON_IDL
 
-#define HPP_EXPOSE_MEMORY_DEALLOCATION(ErrorType) void deleteThis() raises (ErrorType);
+#define HPP_EXPOSE_MEMORY_DEALLOCATION(ErrorType) void deleteThis() raises (ErrorType); void persistantStorage(in boolean persistant) raises (ErrorType);
 
 module hpp
 {

--- a/idl/hpp/corbaserver/tools.idl
+++ b/idl/hpp/corbaserver/tools.idl
@@ -47,6 +47,10 @@ module hpp
 
     void deleteAllServants () raises (Error);
 
+    void deleteExpiredServants () raises (Error);
+
+    Names_t getAllServants() raises (Error);
+
     /// Shutdown the server.
     void shutdown ();
   }; // interface Tools

--- a/idl/hpp/corbaserver/tools.idl
+++ b/idl/hpp/corbaserver/tools.idl
@@ -47,8 +47,6 @@ module hpp
 
     void deleteAllServants () raises (Error);
 
-    void deleteExpiredServants () raises (Error);
-
     Names_t getAllServants() raises (Error);
 
     /// Shutdown the server.

--- a/idl/hpp/core_idl/_constraints.idl
+++ b/idl/hpp/core_idl/_constraints.idl
@@ -25,6 +25,8 @@ module hpp
 
   interface Constraint
   {
+    HPP_EXPOSE_MEMORY_DEALLOCATION(Error)
+
     boolean apply (inout floatSeq config) raises (Error);
 
     string name () raises (Error);

--- a/idl/hpp/core_idl/distances.idl
+++ b/idl/hpp/core_idl/distances.idl
@@ -18,6 +18,8 @@ module hpp
 
   interface Distance
   {
+    HPP_EXPOSE_MEMORY_DEALLOCATION(Error)
+
     value_type call (in floatSeq q1, in floatSeq q2) raises (Error);
     //-> operator()
   }; // interface Distance

--- a/idl/hpp/core_idl/path_validations.idl
+++ b/idl/hpp/core_idl/path_validations.idl
@@ -29,6 +29,8 @@ module hpp
 
   interface ConfigValidation
   {
+    HPP_EXPOSE_MEMORY_DEALLOCATION(Error)
+
     boolean validate (in floatSeq config, out ValidationReport report) raises (Error);
     //* using namespace hpp::core;
     //* ValidationReportPtr_t vr;
@@ -62,6 +64,8 @@ module hpp
 
   interface PathValidation
   {
+    HPP_EXPOSE_MEMORY_DEALLOCATION(Error)
+
     boolean validate (in Path p, in boolean reverse, out Path validPart, out PathValidationReport report) raises (Error);
     //* using namespace hpp::core;
     //* PathPtr_t _p (::hpp::corbaServer::reference_to_servant_base<core::Path>(server_, p)->get());

--- a/idl/hpp/core_idl/steering_methods.idl
+++ b/idl/hpp/core_idl/steering_methods.idl
@@ -21,6 +21,8 @@ module hpp
 
   interface SteeringMethod
   {
+    HPP_EXPOSE_MEMORY_DEALLOCATION(Error)
+
     Path call (in floatSeq q1, in floatSeq q2) raises (Error);
     //-> operator()
 

--- a/idl/hpp/pinocchio_idl/robots.idl
+++ b/idl/hpp/pinocchio_idl/robots.idl
@@ -102,7 +102,7 @@ module hpp
       void controlComputation(in short flag) raises (Error);
       //* getT()->controlComputation(hpp::pinocchio::Computation_t(flag));
 
-      void computeForwardKinematics() raises (Error);
+      void computeForwardKinematics(in short computationFlag) raises (Error);
 
       void computeFramesForwardKinematics () raises (Error);
 

--- a/include/hpp/corbaserver/read-write-lock.hh
+++ b/include/hpp/corbaserver/read-write-lock.hh
@@ -1,0 +1,70 @@
+// Copyright (C) 2023 by Joseph Mirabel
+//
+// This code was taken from https://stackoverflow.com/a/28121513
+
+#include <condition_variable>
+#include <mutex>
+
+namespace hpp {
+namespace corbaServer {
+
+/// Synchronization class that ensures the following.
+/// - A Write block Weads and Writes.
+/// - Reads are only blocked by Writes, not by other Reads.
+/// - Write is favored over Reads.
+///
+/// This code was taken from https://stackoverflow.com/a/28121513
+class ReadWriteLock {
+ public:
+  ReadWriteLock()
+      : shared_(),
+        readerQ_(),
+        writerQ_(),
+        activeReaders_(0),
+        waitingWriters_(0),
+        activeWriters_(0) {}
+
+  void readLock() {
+    std::unique_lock<std::mutex> lk(shared_);
+    while (waitingWriters_ != 0) readerQ_.wait(lk);
+    ++activeReaders_;
+    lk.unlock();
+  }
+
+  void readUnlock() {
+    std::unique_lock<std::mutex> lk(shared_);
+    --activeReaders_;
+    lk.unlock();
+    writerQ_.notify_one();
+  }
+
+  void writeLock() {
+    std::unique_lock<std::mutex> lk(shared_);
+    ++waitingWriters_;
+    while (activeReaders_ != 0 || activeWriters_ != 0) writerQ_.wait(lk);
+    ++activeWriters_;
+    lk.unlock();
+  }
+
+  void writeUnlock() {
+    std::unique_lock<std::mutex> lk(shared_);
+    --waitingWriters_;
+    --activeWriters_;
+    if (waitingWriters_ > 0)
+      writerQ_.notify_one();
+    else
+      readerQ_.notify_all();
+    lk.unlock();
+  }
+
+ private:
+  std::mutex shared_;
+  std::condition_variable readerQ_;
+  std::condition_variable writerQ_;
+  int activeReaders_;
+  int waitingWriters_;
+  int activeWriters_;
+};
+
+}  // end of namespace corbaServer.
+}  // end of namespace hpp.

--- a/include/hpp/corbaserver/servant-base.hh
+++ b/include/hpp/corbaserver/servant-base.hh
@@ -92,6 +92,8 @@ struct hpp_traits {};
 class AbstractServantKey {
  public:
   virtual Server::ServantKey getServantKey() const = 0;
+
+  virtual bool expired() const = 0;
 };
 
 /// Base class for classes which provides bindings for HPP classes.
@@ -134,6 +136,11 @@ class ServantBase : public AbstractServantBase<T> {
       objectExpired();
     }
     return wk.lock();
+  }
+
+  bool expired() const final {
+    TWkPtr_t wk((StorageElementWkPtr_t)wrappedObject_);
+    return wk.expired();
   }
 
   StorageElementShPtr_t getT() const {

--- a/include/hpp/corbaserver/servant-base.hh
+++ b/include/hpp/corbaserver/servant-base.hh
@@ -180,6 +180,14 @@ class ServantBase : public AbstractServantBase<T> {
     this->server_->poa()->deactivate_object(objectId.in());
   }
 
+  bool deleteIfExpired() {
+    if (expired()) {
+      deleteThis();
+      return true;
+    }
+    return false;
+  }
+
  protected:
   ServantBase(Server* server, const Storage& _s)
       : AbstractServantBase<T>(server), wrappedObject_(_s) {

--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -35,6 +35,7 @@
 #ifndef HPP_CORBASERVER_SERVER_HH
 #define HPP_CORBASERVER_SERVER_HH
 
+#include <boost/thread/mutex.hpp>
 #include <omniORB4/CORBA.h>
 
 #include <hpp/corba/template/server.hh>
@@ -168,6 +169,10 @@ class HPP_CORBASERVER_DLLAPI Server {
 
   void clearServantsMap();
 
+  void removeExpriredServants();
+
+  std::vector<std::string> getAllObjectIds();
+
  private:
   corba::Server<Tools>* tools_;
 
@@ -201,6 +206,8 @@ class HPP_CORBASERVER_DLLAPI Server {
       ServantToServantKeyMap_t;
   ServantKeyToServantMap_t servantKeyToServantMap_;
   ServantToServantKeyMap_t servantToServantKeyMap_;
+  // Mutex for accessing servant / servant key maps.
+  boost::mutex mutex_;
 };
 }  // end of namespace corbaServer.
 }  // end of namespace hpp.

--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -169,8 +169,6 @@ class HPP_CORBASERVER_DLLAPI Server {
 
   void clearServantsMap();
 
-  void removeExpriredServants();
-
   std::vector<std::string> getAllObjectIds();
 
  private:

--- a/include/hpp/corbaserver/server.hh
+++ b/include/hpp/corbaserver/server.hh
@@ -35,13 +35,13 @@
 #ifndef HPP_CORBASERVER_SERVER_HH
 #define HPP_CORBASERVER_SERVER_HH
 
-#include <boost/thread/mutex.hpp>
 #include <omniORB4/CORBA.h>
 
 #include <hpp/corba/template/server.hh>
 #include <hpp/corbaserver/config.hh>
 #include <hpp/corbaserver/fwd.hh>
 #include <hpp/corbaserver/problem-solver-map.hh>
+#include <hpp/corbaserver/read-write-lock.hh>
 
 namespace hpp {
 namespace corbaServer {
@@ -207,7 +207,7 @@ class HPP_CORBASERVER_DLLAPI Server {
   ServantKeyToServantMap_t servantKeyToServantMap_;
   ServantToServantKeyMap_t servantToServantKeyMap_;
   // Mutex for accessing servant / servant key maps.
-  boost::mutex mutex_;
+  ReadWriteLock lock_;
 };
 }  // end of namespace corbaServer.
 }  // end of namespace hpp.

--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -1148,7 +1148,6 @@ void Problem::resetConstraints() {
   if (!problemSolver()->robot()) throw hpp::Error("No robot loaded");
   try {
     problemSolver()->resetConstraints();
-    problemSolver()->robot()->controlComputation(pinocchio::JOINT_POSITION);
   } catch (const std::exception& exc) {
     throw hpp::Error(exc.what());
   }

--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -746,7 +746,6 @@ TransformSeq* Robot::getLinksPosition(const floatSeq& dofArray,
     Configuration_t config = floatSeqToConfig(_robot, dofArray, true);
     DeviceSync robot(_robot);
     robot.currentConfiguration(config);
-    robot.computeForwardKinematics();
     robot.computeFramesForwardKinematics();
 
     const Model& model(robot.model());
@@ -1228,12 +1227,7 @@ hpp::floatSeq* Robot::getCenterOfMass() {
 hpp::floatSeq* Robot::getCenterOfMassVelocity() {
   try {
     DevicePtr_t robot = getRobotOrThrow(problemSolver());
-    pinocchio::Computation_t flags = robot->computationFlag();
-    if (!(flags & pinocchio::COM) || (flags & pinocchio::JACOBIAN)) {
-      robot->controlComputation(pinocchio::COMPUTE_ALL);
-      robot->computeForwardKinematics();
-      robot->controlComputation(flags);
-    }
+    robot->computeForwardKinematics(pinocchio::COMPUTE_ALL);
     return vectorToFloatSeq(robot->jacobianCenterOfMass() *
                             robot->currentVelocity());
   } catch (const std::exception& exc) {
@@ -1246,12 +1240,7 @@ hpp::floatSeq* Robot::getCenterOfMassVelocity() {
 hpp::floatSeqSeq* Robot::getJacobianCenterOfMass() {
   try {
     DevicePtr_t robot = getRobotOrThrow(problemSolver());
-    pinocchio::Computation_t flags = robot->computationFlag();
-    if (!(flags & pinocchio::COM) || (flags & pinocchio::JACOBIAN)) {
-      robot->controlComputation(pinocchio::COMPUTE_ALL);
-      robot->computeForwardKinematics();
-      robot->controlComputation(flags);
-    }
+    robot->computeForwardKinematics(pinocchio::COMPUTE_ALL);
     const ComJacobian_t& jacobian = robot->jacobianCenterOfMass();
     return matrixToFloatSeqSeq(jacobian);
   } catch (const std::exception& exc) {

--- a/src/server.cc
+++ b/src/server.cc
@@ -172,14 +172,6 @@ class Tools : public virtual POA_hpp::Tools {
     }
   }
 
-  virtual void deleteExpiredServants() override {
-    try {
-      server_->removeExpriredServants();
-    } catch (const std::exception& e) {
-      throw hpp::Error(e.what());
-    }
-  }
-
   virtual Names_t* getAllServants() override {
     try {
       std::vector<std::string> names{server_->getAllObjectIds()};
@@ -458,29 +450,6 @@ void Server::clearServantsMap() {
   }
   servantKeyToServantMap_.clear();
   servantToServantKeyMap_.clear();
-  lock_.writeUnlock();
-}
-
-void Server::removeExpriredServants() {
-  PortableServer::POA_var _poa(poa());
-  ServantKeyToServantMap_t k2sMap;
-  ServantToServantKeyMap_t s2kMap;
-
-  lock_.writeLock();
-  for (const auto& pair : servantKeyToServantMap_) {
-    AbstractServantKey* sk = dynamic_cast<AbstractServantKey*>(pair.second);
-    if (sk == NULL || !sk->expired()) {
-      // Remove the object
-      PortableServer::ObjectId_var objectId = _poa->servant_to_id(pair.second);
-      _poa->deactivate_object(objectId.in());
-    } else {
-      // Keep the object
-      k2sMap.insert(pair);
-      s2kMap.insert(std::make_pair(pair.second, pair.first));
-    }
-  }
-  servantKeyToServantMap_.swap(k2sMap);
-  servantToServantKeyMap_.swap(s2kMap);
   lock_.writeUnlock();
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set_tests_properties("py-robot" PROPERTIES RUN_SERIAL "ON")
 set_tests_properties("py-utils" PROPERTIES RUN_SERIAL "ON")
 set_tests_properties("py-port" PROPERTIES RUN_SERIAL "ON")
 set_tests_properties("py-path-serialization" PROPERTIES RUN_SERIAL "ON")
+set_tests_properties("py-problem" PROPERTIES RUN_SERIAL "ON")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hppcorbaserver.sh
                ${CMAKE_CURRENT_BINARY_DIR}/hppcorbaserver.sh)

--- a/tests/problem.py
+++ b/tests/problem.py
@@ -1,11 +1,28 @@
 import unittest
 
 # Check imports
+from hpp.corbaserver.tools import Tools
 from hpp.corbaserver import Client
 from hpp.utils import ServerManager
 
 
 class Test(unittest.TestCase):
+    def test_tools(self):
+        with ServerManager("../src/hppcorbaserver"):
+            tools = Tools()
+            cl = Client()
+            cl.robot.createRobot("foo")
+            pb = cl.problem.getProblem()
+
+            object_ids = tools.getAllServants()
+            assert len(object_ids) == 1
+            assert object_ids[0] == cl.orb.object_to_string(pb)
+
+            pb2 = cl.orb.string_to_object(object_ids[0])
+            assert type(pb) == type(pb2)
+            pb2.persistantStorage(False)
+
+
     def test_createConstraints(self):
         with ServerManager("../src/hppcorbaserver"):
             self.client = Client()

--- a/tests/problem.py
+++ b/tests/problem.py
@@ -22,7 +22,6 @@ class Test(unittest.TestCase):
             assert type(pb) == type(pb2)
             pb2.persistantStorage(False)
 
-
     def test_createConstraints(self):
         with ServerManager("../src/hppcorbaserver"):
             self.client = Client()

--- a/tests/robot.py
+++ b/tests/robot.py
@@ -71,9 +71,6 @@ class Test(unittest.TestCase):
             c_robot.setCurrentVelocity(v)
             c_robot.setCurrentAcceleration(a)
 
-            c_robot.controlComputation(1)
-            assert c_robot.computationFlag() == 1
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The PR changes:
- Follows https://github.com/humanoid-path-planner/hpp-pinocchio/pull/188.
- Add function `persistantStorage` to all IDL objects to allow the memory not to be owned by the servant.
- Add functions to better manage the memory:
  - `deleteExpiredServants` removed servants whose object has already been deleted.
  - `getAllServants` returns a list of object IDs that allows to access all the objects from Python.
  - add a mutex to access the servant maps.