### PR TITLE
[cmake] Create directory where omniidl will produce files.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(IDL_SOURCES obstacle problem robot tools)
 omniidl_include_directories(${CMAKE_SOURCE_DIR}/idl)
 include_directories(${CMAKE_BINARY_DIR}/src)
 
+make_directory(${CMAKE_BINARY_DIR}/src/hpp/corbaserver)
 foreach(IDL ${IDL_SOURCES})
   generate_idl_cpp(
     hpp/corbaserver/${IDL} ${CMAKE_SOURCE_DIR}/idl/hpp/corbaserver


### PR DESCRIPTION
For a mysterious reason, this directory is not created anymore and make installation from scratch fail.