### PR TITLE
Fix pinocchio include order issue.

### DIFF
--- a/src/robot.impl.cc
+++ b/src/robot.impl.cc
@@ -31,6 +31,10 @@
 //
 // See the COPYING file for more information.
 
+// clang-format off
+#include <pinocchio/fwd.hpp>
+// clang-format on
+
 #include "robot.impl.hh"
 
 #include <coal/BVH/BVH_model.h>
@@ -58,7 +62,6 @@
 #include <hpp/util/debug.hh>
 #include <hpp/util/exception-factory.hh>
 #include <iostream>
-#include <pinocchio/fwd.hpp>
 #include <pinocchio/multibody/fcl.hpp>
 #include <pinocchio/multibody/geometry.hpp>
 #include <pinocchio/multibody/model.hpp>


### PR DESCRIPTION
This issue arises on PAL Ubuntu22.04 "alum".

```
$ gcc --version
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ cmake --version
cmake version 3.22.1
CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

cmake output: `-- C++ standard sufficient: Minimal required 14, currently defined: 17`